### PR TITLE
pc - update instructions for running frontend in second window

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ If it doesn't work at first, e.g. you have a blank page on  <http://localhost:80
 If you see the following on localhost, make sure that you also have the frontend code running in a separate window.
 
 ```
-Failed to connect to the frontend server! You may have forgotten to run npm start in a separate ./dev_environment window (or it hasn't loaded yet).
+Failed to connect to the frontend server... On Heroku, be sure that PRODUCTION is defined.  On localhost, open a second terminal window, cd into frontend and type: npm install; npm start";
 ```
 
 # Getting Started on Heroku
@@ -55,10 +55,10 @@ On Heroku, you'll need to set the following configuration variable:
 
 You'll also need to follow the OAuth set up instructions here: [`docs/oauth.md`](docs/oauth.md).
 
-If you get the following message, it probably means that you failed to setup one or more of the environment variables:
+If you get the following message on Heroku, it probably means that you failed to setup the `PRODUCTION` environment variable.
 
 ```
-Failed to connect to the frontend server! You may have forgotten to run npm start in a separate ./dev_environment window (or it hasn't loaded yet).
+Failed to connect to the frontend server... On Heroku, be sure that PRODUCTION is defined.  On localhost, open a second terminal window, cd into frontend and type: npm install; npm start";
 ```
 
 # Accessing swagger

--- a/src/main/java/edu/ucsb/cs156/example/controllers/FrontendProxyController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/FrontendProxyController.java
@@ -19,7 +19,8 @@ public class FrontendProxyController {
       return proxy.uri("http://localhost:3000/" + path).get();
     } catch (ResourceAccessException e) {
       if (e.getCause() instanceof ConnectException) {
-        return ResponseEntity.ok("Failed to connect to the frontend server! You may have forgotten to run npm start in a separate ./dev_environment window (or it hasn't loaded yet).");
+        String instructions = "Failed to connect to the frontend server... On Heroku, be sure that PRODUCTION is defined.  On localhost, open a second terminal window, cd into frontend and type: npm install; npm start";
+        return ResponseEntity.ok(instructions);
       }
       throw e;
     }


### PR DESCRIPTION
# Overview

In this PR, we clarify the instructions that come up when the backend failes to reach the frontend server.

The old instructions were optimized for the docker environment, which is not the main way that developers are working with the repo at the moment:

```
Failed to connect to the frontend server! You may have forgotten to run npm start in a separate ./dev_environment window (or it hasn't loaded yet).
```

The new instructions better reflect the majority of use cases where this warning will arise in practice:

```
Failed to connect to the frontend server... On Heroku, be sure that PRODUCTION is defined. On localhost, open a second terminal window, cd into frontend and type: npm install; npm start";
```