### PR TITLE
pc - database example, todos entity/repository/controller and swagger csrf fix

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/config/SecurityConfig.java
+++ b/src/main/java/edu/ucsb/cs156/example/config/SecurityConfig.java
@@ -1,5 +1,9 @@
 package edu.ucsb.cs156.example.config;
 
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -43,45 +47,58 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
   @Autowired
   UserRepository userRepository;
 
-
   public static class MyCsrfRequestMatcher implements RequestMatcher {
 
     // Always allow the HTTP GET method
     private Pattern allowedMethods = Pattern.compile("^GET$");
-   
+
+    public static String constructSwaggerUrl(HttpServletRequest request) {
+      try {
+        URL url = new URL(request.getRequestURL().toString());
+        String host = url.getHost();
+        String scheme = url.getProtocol();
+        int port = url.getPort();
+        return scheme + "://" + host + ( (port == 80 || port==-1) ? "" : (":" + port) ) + "/swagger-ui/index.html";
+      } catch (MalformedURLException mue) {
+        return "";
+      }
+    }
+
     private String localhostSwagger = "http://localhost:8080/swagger-ui/index.html";
+
     @Override
     public boolean matches(HttpServletRequest request) {
+
+      String swaggerReferer = constructSwaggerUrl(request);
       String referer = request.getHeader("referer");
-      log.info("referer={}",referer);
       if (allowedMethods.matcher(request.getMethod()).matches()) {
-          return false;
+        return false;
       }
       if (referer.equals(localhostSwagger)) {
-          return false;
+        return false;
+      }
+      if (referer.equals(swaggerReferer)) {
+        return false;
       }
       return true;
     }
 
-}
+  }
 
   @Override
   protected void configure(HttpSecurity http) throws Exception {
     http.authorizeRequests(authorize -> authorize
-          .anyRequest().permitAll()
-        )
+        .anyRequest().permitAll())
         .exceptionHandling(handlingConfigurer -> handlingConfigurer
-          .authenticationEntryPoint(new Http403ForbiddenEntryPoint())
-        )
-        .oauth2Login(oauth2 -> oauth2.userInfoEndpoint(userInfo -> userInfo.userAuthoritiesMapper(this.userAuthoritiesMapper())))
+            .authenticationEntryPoint(new Http403ForbiddenEntryPoint()))
+        .oauth2Login(
+            oauth2 -> oauth2.userInfoEndpoint(userInfo -> userInfo.userAuthoritiesMapper(this.userAuthoritiesMapper())))
         .csrf(csrf -> csrf
-            .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse()
-            ).requireCsrfProtectionMatcher(new MyCsrfRequestMatcher())
-        )
+            .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
+            .requireCsrfProtectionMatcher(new MyCsrfRequestMatcher()))
         .logout(logout -> logout
             .logoutRequestMatcher(new AntPathRequestMatcher("/logout"))
-            .logoutSuccessUrl("/")
-        );
+            .logoutSuccessUrl("/"));
   }
 
   @Override
@@ -116,6 +133,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
       return mappedAuthorities;
     };
   }
+
   public boolean isAdmin(String email) {
     if (adminEmails.contains(email)) {
       return true;

--- a/src/main/java/edu/ucsb/cs156/example/config/SecurityConfig.java
+++ b/src/main/java/edu/ucsb/cs156/example/config/SecurityConfig.java
@@ -6,6 +6,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.regex.Pattern;
+
+import javax.servlet.http.HttpServletRequest;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -22,6 +25,7 @@ import org.springframework.security.oauth2.core.user.OAuth2UserAuthority;
 import org.springframework.security.web.authentication.Http403ForbiddenEntryPoint;
 import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcher;
 
 import edu.ucsb.cs156.example.entities.User;
 import edu.ucsb.cs156.example.repositories.UserRepository;
@@ -39,6 +43,28 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
   @Autowired
   UserRepository userRepository;
 
+
+  public static class MyCsrfRequestMatcher implements RequestMatcher {
+
+    // Always allow the HTTP GET method
+    private Pattern allowedMethods = Pattern.compile("^GET$");
+   
+    private String localhostSwagger = "http://localhost:8080/swagger-ui/index.html";
+    @Override
+    public boolean matches(HttpServletRequest request) {
+      String referer = request.getHeader("referer");
+      log.info("referer={}",referer);
+      if (allowedMethods.matcher(request.getMethod()).matches()) {
+          return false;
+      }
+      if (referer.equals(localhostSwagger)) {
+          return false;
+      }
+      return true;
+    }
+
+}
+
   @Override
   protected void configure(HttpSecurity http) throws Exception {
     http.authorizeRequests(authorize -> authorize
@@ -49,13 +75,13 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         )
         .oauth2Login(oauth2 -> oauth2.userInfoEndpoint(userInfo -> userInfo.userAuthoritiesMapper(this.userAuthoritiesMapper())))
         .csrf(csrf -> csrf
-            .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
+            .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse()
+            ).requireCsrfProtectionMatcher(new MyCsrfRequestMatcher())
         )
         .logout(logout -> logout
             .logoutRequestMatcher(new AntPathRequestMatcher("/logout"))
             .logoutSuccessUrl("/")
         );
-    ;
   }
 
   @Override

--- a/src/main/java/edu/ucsb/cs156/example/controllers/TodosController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/TodosController.java
@@ -1,0 +1,72 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.entities.Todo;
+import edu.ucsb.cs156.example.models.CurrentUser;
+import edu.ucsb.cs156.example.repositories.TodoRepository;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import lombok.extern.slf4j.Slf4j;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Api(description = "Todos")
+@RequestMapping("/api/todos")
+@RestController
+@Slf4j
+public class TodosController extends ApiController {
+
+    @Autowired
+    TodoRepository todoRepository;
+
+    @Autowired
+    ObjectMapper mapper;
+
+    @ApiOperation(value = "List all todos")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @GetMapping("/admin/all")
+    public Iterable<Todo> allUsersTodos() {
+        Iterable<Todo> todos = todoRepository.findAll();
+        return todos;
+    }
+
+    @ApiOperation(value = "List this user's todos")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/all")
+    public Iterable<Todo> thisUsersTodos() {
+        CurrentUser currentUser = getCurrentUser();
+        Iterable<Todo> todos = todoRepository. findAllByUserId(currentUser.getUser().getId());
+        return todos;
+    }
+    
+    @ApiOperation(value = "Create a new Todo")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @PostMapping("/post")
+    public Todo postTodo(
+        @ApiParam("title") @RequestParam String title,
+        @ApiParam("details") @RequestParam String details,
+        @ApiParam("done") @RequestParam Boolean done
+    ) {
+        log.info("POST /api/todos/put");
+        CurrentUser currentUser = getCurrentUser();
+        Todo todo = new Todo();
+        todo.setUser(currentUser.getUser());
+        todo.setTitle(title);
+        todo.setDetails(details);
+        todo.setDone(done);
+        Todo savedTodo = todoRepository.save(todo);
+        return savedTodo;
+    }
+
+}

--- a/src/main/java/edu/ucsb/cs156/example/entities/Todo.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/Todo.java
@@ -1,0 +1,36 @@
+package edu.ucsb.cs156.example.entities;
+
+
+import javax.persistence.Entity;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.GeneratedValue;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "todos")
+public class Todo {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+
+  // This establishes that many todos can belong to one user
+  // Only the user_id is stored in the table, and through it we
+  // can access the user's details
+
+  @ManyToOne
+  @JoinColumn(name = "user_id")
+  private User user;
+  private String title;
+  private String details;
+  private boolean done;
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/TodoRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/TodoRepository.java
@@ -1,0 +1,12 @@
+package edu.ucsb.cs156.example.repositories;
+
+import edu.ucsb.cs156.example.entities.Todo;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface TodoRepository extends CrudRepository<Todo, Long> {
+  Iterable<Todo> findAllByUserId(Long user_id);
+}

--- a/src/main/resources/application-development.properties
+++ b/src/main/resources/application-development.properties
@@ -6,3 +6,6 @@ spring.datasource.password=password
 spring.h2.console.settings.web-allow-others=true
 spring.h2.console.enabled=true
 app.showSwaggerUILink=true
+
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.datasource.initialization-mode=always

--- a/src/main/resources/application-production.properties
+++ b/src/main/resources/application-production.properties
@@ -1,3 +1,5 @@
 spring.datasource.url=${JDBC_DATABASE_URL}
 spring.datasource.username=${JDBC_DATABASE_USERNAME}
 spring.datasource.password=${JDBC_DATABASE_PASSWORD}
+
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQL9Dialect


### PR DESCRIPTION
# Overview

In this PR, we add an example of database operations to the code base.

First, we disable CSRF protection for post requests that come from localhost swagger.

Then we add an entity and repository for `todo` records.  These are set up with a foreign key to the `users` table; to make this work properly, we had to make sure that the SQL dialects were set properly in both the development and production environments.

Then, we add controller endpoints to 
* list all todos for admin users (regardless of the owner)
* list only todos for a given user (for regular users)
* create a todo attached to the current user


# New API endpoints added:

![image](https://user-images.githubusercontent.com/1119017/151627172-057b2130-d00a-4d4b-a4d3-e62a9a58c7a5.png)


# Issues Addressed

This addresses issue #7 