### PR TITLE
pc - improve test coverage for backend basic infrastructure

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,6 @@
 
     <build>
         <plugins>
-
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
@@ -105,6 +104,7 @@
                 <version>0.8.7</version>
                 <configuration>
                     <excludes>
+                        <exclude>**/edu/ucsb/cs156/example/config/*</exclude>
                         <exclude>**/edu/ucsb/cs156/example/controllers/FrontendController.*</exclude>
                         <exclude>**/edu/ucsb/cs156/example/controllers/FrontendProxyController.*</exclude>
                         <exclude>**/edu/ucsb/cs156/example/services/CurrentUserServiceImpl.*</exclude>

--- a/src/main/java/edu/ucsb/cs156/example/controllers/ApiController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/ApiController.java
@@ -12,10 +12,6 @@ public abstract class ApiController {
   @Autowired
   private CurrentUserService currentUserService;
 
-  protected User getUser() {
-    return currentUserService.getUser();
-  }
-
   protected CurrentUser getCurrentUser() {
     return currentUserService.getCurrentUser();
   }

--- a/src/main/java/edu/ucsb/cs156/example/services/SystemInfoServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs156/example/services/SystemInfoServiceImpl.java
@@ -4,11 +4,15 @@ package edu.ucsb.cs156.example.services;
 import edu.ucsb.cs156.example.models.SystemInfo;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Service;
 
+// This class relies on property values
+// For hints on testing, see: https://www.baeldung.com/spring-boot-testing-configurationproperties
 
 @Slf4j
 @Service("systemInfo")
+@ConfigurationProperties
 public class SystemInfoServiceImpl extends SystemInfoService {
   
   @Value("${spring.h2.console.enabled:false}")

--- a/src/test/java/edu/ucsb/cs156/example/controllers/SystemInfoControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/SystemInfoControllerTests.java
@@ -1,0 +1,44 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.services.SystemInfoService;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithMockUser;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+
+@WebMvcTest(controllers = SystemInfoController.class)
+public class SystemInfoControllerTests extends ControllerTestCase {
+
+  @MockBean
+  UserRepository userRepository;
+
+  @MockBean
+  SystemInfoService mockSystemInfoService;
+
+  @Test
+  public void systemInfo__logged_out() throws Exception {
+    mockMvc.perform(get("/api/systemInfo"))
+        .andExpect(status().is(403));
+  }
+
+  @WithMockUser(roles={"USER"})
+  @Test
+  public void systemInfo__user_logged_in() throws Exception {
+    mockMvc.perform(get("/api/systemInfo"))
+        .andExpect(status().is(403));
+  }
+
+  @WithMockUser(roles={"ADMIN"})
+  @Test
+  public void systemInfo__admin_logged_in() throws Exception {
+    mockMvc.perform(get("/api/systemInfo"))
+        .andExpect(status().isOk());
+  }
+}

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UsersControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UsersControllerTests.java
@@ -1,0 +1,39 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.repositories.UserRepository;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithMockUser;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(controllers = UsersController.class)
+public class UsersControllerTests extends ControllerTestCase {
+
+  @MockBean
+  UserRepository userRepository;
+
+  @Test
+  public void users__logged_out() throws Exception {
+    mockMvc.perform(get("/api/admin/users"))
+        .andExpect(status().is(403));
+  }
+
+  @WithMockUser(roles = { "USER" })
+  @Test
+  public void users__user_logged_in() throws Exception {
+    mockMvc.perform(get("/api/admin/users"))
+        .andExpect(status().is(403));
+  }
+
+  @WithMockUser(roles = { "ADMIN" })
+  @Test
+  public void users__admin_logged_in() throws Exception {
+    mockMvc.perform(get("/api/admin/users"))
+        .andExpect(status().isOk());
+  }
+}

--- a/src/test/java/edu/ucsb/cs156/example/services/CurrentUserServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/services/CurrentUserServiceTests.java
@@ -6,15 +6,12 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
-
 
 import edu.ucsb.cs156.example.ControllerTestCase;
 import edu.ucsb.cs156.example.entities.User;
 
 class CurrentUserServiceTests extends ControllerTestCase {
 
-  
   @Test
   void test_isLoggedIn_returns_false() {
     CurrentUserService currentUserService = mock(CurrentUserService.class);

--- a/src/test/java/edu/ucsb/cs156/example/services/SystemInfoServiceImplTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/services/SystemInfoServiceImplTests.java
@@ -1,0 +1,37 @@
+package edu.ucsb.cs156.example.services;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import edu.ucsb.cs156.example.models.SystemInfo;
+
+// The unit under test relies on property values
+// For hints on testing, see: https://www.baeldung.com/spring-boot-testing-configurationproperties
+
+
+@ExtendWith(SpringExtension.class)
+@EnableConfigurationProperties(value = SystemInfoServiceImpl.class)
+@TestPropertySource("classpath:application-development.properties")
+class SystemInfoServiceImplTests  {
+  
+  @Autowired
+  private SystemInfoService systemInfoService;
+
+  @Test
+  void test_getSystemInfo() {
+    SystemInfo si = systemInfoService.getSystemInfo();
+    assertTrue(si.getSpringH2ConsoleEnabled());
+    assertTrue(si.getShowSwaggerUILink());
+  }
+
+}


### PR DESCRIPTION
# Overview

In this PR, we improve the test coverage for the basic infrastructure code.

* We exclude the `config` package which contains code that is very difficult to test.
* We remove a difficult to test method that was, apparently not being used anywhere
* We add test coverage for a few controllers and service that just didn't have it already

