### PR TITLE
pc - WIP on user details

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/models/UserDetailsImpl.java
+++ b/src/main/java/edu/ucsb/cs156/example/models/UserDetailsImpl.java
@@ -1,0 +1,69 @@
+package edu.ucsb.cs156.example.models;
+
+import java.util.Collection;
+import java.util.Optional;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import edu.ucsb.cs156.example.entities.User;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * This class implements a UserDetails similar to the MyUserPrincipal from
+ * this article
+ * https://www.baeldung.com/spring-security-authentication-with-a-database
+ */
+
+@Slf4j
+@Data
+@AllArgsConstructor
+public class UserDetailsImpl implements UserDetails {
+    private User user;
+
+    @Override
+    public String getUsername() {
+        return user.getEmail();
+    }
+
+    @Override
+    public String getPassword() {
+        return "";
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public java.util.Collection<? extends GrantedAuthority> getAuthorities() {
+        SecurityContext securityContext = SecurityContextHolder.getContext();
+        Authentication authentication = securityContext.getAuthentication();
+        Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
+        log.info("authorities={}", authorities);
+        return authorities;
+    }
+
+}

--- a/src/main/java/edu/ucsb/cs156/example/services/UserDetailsServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs156/example/services/UserDetailsServiceImpl.java
@@ -1,0 +1,35 @@
+package edu.ucsb.cs156.example.services;
+
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Autowired;
+
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Service;
+
+import edu.ucsb.cs156.example.entities.User;
+import edu.ucsb.cs156.example.models.UserDetailsImpl;
+import edu.ucsb.cs156.example.repositories.UserRepository;
+
+@Service
+public class UserDetailsServiceImpl implements UserDetailsService {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    public static class UsernameNotFoundException extends RuntimeException {
+        public UsernameNotFoundException(String message) {
+            super(message);
+        }
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String email) {
+        Optional<User> user = userRepository.findByEmail(email);
+        if (!user.isPresent()) {
+            throw new UsernameNotFoundException(email);
+        }
+        return new UserDetailsImpl(user.get());
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/example/services/MockUserDetailsServiceImpl.java
+++ b/src/test/java/edu/ucsb/cs156/example/services/MockUserDetailsServiceImpl.java
@@ -1,0 +1,65 @@
+package edu.ucsb.cs156.example.services;
+
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Autowired;
+
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Service;
+
+import edu.ucsb.cs156.example.entities.User;
+import edu.ucsb.cs156.example.models.UserDetailsImpl;
+import edu.ucsb.cs156.example.repositories.UserRepository;
+
+@Service
+public class MockUserDetailsServiceImpl implements UserDetailsService {
+
+    public static User adminUser = initializeAdminUser();
+    public static User regularUser = initializeRegularUser();
+    
+    private static User initializeAdminUser() {
+        User adminUser = User.builder()
+        .googleSub("adminUser")
+        .email("admin@example.org")
+        .pictureUrl("https://example.org/admin.jpg")
+        .fullName("Admin User")
+        .givenName("Admin")
+        .familyName("User")
+        .emailVerified(true)
+        .locale("locale")
+        .hostedDomain("example.org")
+        .admin(true)
+        .build();
+        return adminUser;
+    }
+
+    private static User initializeRegularUser() {
+        User regularUser = User.builder()
+        .googleSub("user")
+        .email("user@example.org")
+        .pictureUrl("https://example.org/user.jpg")
+        .fullName("Regular User")
+        .givenName("Regular")
+        .familyName("User")
+        .emailVerified(true)
+        .locale("locale")
+        .hostedDomain("example.org")
+        .admin(false)
+        .build();
+        return regularUser;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String email) {
+
+        if (email.equals("admin@example.org")) {
+            return new UserDetailsImpl(adminUser);
+        } else if (email.equals("user@example.org")) {
+            return new UserDetailsImpl(regularUser);
+        } else {
+            throw new RuntimeException("unknown mock user details");
+        }
+
+    }
+}


### PR DESCRIPTION
# Overview

In this draft PR, we try to implement the [`UserDetailsService`] described here:

* <https://docs.spring.io/spring-security/site/docs/4.2.x/reference/html/test-method.html#test-method-withuserdetails>

The intention is to try to avoid the awkward duplicate code as in this example. 

```
@WithMockUser(roles = { "USER" })
    @Test
    public void api_todos_post__user_logged_in__returns_200() throws Exception {
        User u = User.builder().build();
        loginAs(u);
        mockMvc.perform(
                post("/api/todos/post?title=The Title&details=The Details&done=false")
                        .with(csrf()))
                .andExpect(status().isOk());
    }
```

Here we have to do both 
* `@WithMockUser(roles = { "USER" })` in order to get past the `@PreAuthorize("hasRole('ROLE_USER')")`
*  and also `User u = User.builder().build(); loginAs(u);` because the code in the controller users `currentUserService` to get a user to add to the newly created todo item.

The CurrentUserService exists to supply the currently logged in user, but also to supply the ` Collection<? extends GrantedAuthority> ` that supplies the list of roles that the user has.   As it turns out, this is also the contract for `UserDetailsService`, so we are essentially reinventing the wheel by creating a CurrentUserService.

If we could create one that corresponds with the contract, we might be able to hook into the various decorators such as 
`@WithMockUser` and  

```
@WithUserDetails(value="customUsername", userDetailsServiceBeanName="myUserDetailsService")
```

that are described in the Spring Security documentation: 
* <https://docs.spring.io/spring-security/site/docs/4.2.x/reference/html/test-method.html#test-method-withuserdetails>

