### PR TITLE
pc - update Swagger to have link back to home page

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/config/SpringFoxConfig.java
+++ b/src/main/java/edu/ucsb/cs156/example/config/SpringFoxConfig.java
@@ -1,9 +1,12 @@
 package edu.ucsb.cs156.example.config;
 
+import java.util.Collections;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import springfox.documentation.service.Contact;
 import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.service.ApiInfo;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spring.web.plugins.Docket;
 
@@ -12,17 +15,26 @@ import static springfox.documentation.builders.PathSelectors.regex;
 /**
  * Configuration for Swagger, a package that provides documentation
  * for REST API endpoints.
- * @see <a href="https://www.baeldung.com/swagger-2-documentation-for-spring-rest-api">https://www.baeldung.com/swagger-2-documentation-for-spring-rest-api</a>
+ * 
+ * @see <a href=
+ *      "https://www.baeldung.com/swagger-2-documentation-for-spring-rest-api">https://www.baeldung.com/swagger-2-documentation-for-spring-rest-api</a>
  */
 
 @Configuration
-public class SpringFoxConfig {                                    
+public class SpringFoxConfig {
     @Bean
-    public Docket api() { 
+    public Docket api() {
         return new Docket(DocumentationType.SWAGGER_2)
-          .select()              
-          .apis(RequestHandlerSelectors.any())    
-          .paths(regex("/api/.*"))                      
-          .build();                                           
+                .apiInfo(apiInfo())
+                .select()
+                .apis(RequestHandlerSelectors.any())
+                .paths(regex("/api/.*"))
+                .build();
+
     }
+
+    private ApiInfo apiInfo() {
+        return new ApiInfo("demo-spring-react-example-v2", "<a href=\"/\">home</a>", null, null, null, null, null, Collections.EMPTY_LIST);
+    }
+
 }


### PR DESCRIPTION
# Overview

In this PR, we add a link back to the home page of the application at the top of the swagger home page.

# Before

<img width="520" alt="image" src="https://user-images.githubusercontent.com/1119017/151681698-d02930fd-0352-41b5-b92c-5eb88ef27fde.png">

# After

<img width="693" alt="image" src="https://user-images.githubusercontent.com/1119017/151681715-a95d5de0-116a-4a2a-93f8-09168622fef1.png">


