### PR TITLE
pc - make script to create auxilliary repos

### DIFF
--- a/.github/workflows/publish-00-docs-to-github-pages-setup.yml
+++ b/.github/workflows/publish-00-docs-to-github-pages-setup.yml
@@ -1,38 +1,43 @@
 
 name: Publish 00 docs create repos
-  push:
+on: 
+  pull_request:
     branches:
-      - pc-improve-docs-repo-setup
+      - main
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     steps:
-      - name: Create -docs repo
-          working-directory: .
+      - name: "Create -docs repo"
+        working-directory: .
+        continue-on-error: true
         run: |
-          OWNER_PLUS_REPOSITORY=${{github.repository}}
-          OWNER=${{ github.repository_owner }}
-          REPOSITORY=${OWNER_PLUS_REPOSITORY/$OWNER\//}
-          HOMEPAGE="https://${OWNER}.github.io/${REPOSITORY}${SUFFIX}"
-          NEW_REPO=${OWNER_PLUS_REPOSITORY}${SUFFIX}
           SUFFIX="-docs"
           DESC="Documentation for ${OWNER_PLUS_REPOSITORY}"
-          gh repo create ${NEW_REPO} --public --description ${DESC} --homepage ${HOMEPAGE}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Create -docs-qa repo
-          working-directory: .
-        run: |
+          TEMPLATE="https://github.com/ucsb-cs156-w22/TEMPLATE-docs"
           OWNER_PLUS_REPOSITORY=${{github.repository}}
           OWNER=${{ github.repository_owner }}
           REPOSITORY=${OWNER_PLUS_REPOSITORY/$OWNER\//}
           HOMEPAGE="https://${OWNER}.github.io/${REPOSITORY}${SUFFIX}"
           NEW_REPO=${OWNER_PLUS_REPOSITORY}${SUFFIX}
-          SUFFIX="-docs-qa"
-          DESC="Documentation for QA site for ${OWNER_PLUS_REPOSITORY}"
-          gh repo create ${NEW_REPO} --public --description ${DESC} --homepage ${HOMEPAGE}
+        
+          gh repo create ${NEW_REPO} --public --description "${DESC}" 
+          gh repo edit ${NEW_REPO} --homepage ${HOMEPAGE}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        env: 
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    
+          GITHUB_TOKEN: ${{ secrets.DOCS_TOKEN }}
+      - name: "Set homepage in -docs repo"
+        working-directory: .
+        continue-on-error: true
+        run: |
+          SUFFIX="-docs"
+          DESC="Documentation for ${OWNER_PLUS_REPOSITORY}"
+          TEMPLATE="https://github.com/ucsb-cs156-w22/TEMPLATE-docs"
+          OWNER_PLUS_REPOSITORY=${{github.repository}}
+          OWNER=${{ github.repository_owner }}
+          REPOSITORY=${OWNER_PLUS_REPOSITORY/$OWNER\//}
+          HOMEPAGE="https://${OWNER}.github.io/${REPOSITORY}${SUFFIX}"
+          NEW_REPO=${OWNER_PLUS_REPOSITORY}${SUFFIX}
+          gh repo edit ${NEW_REPO} --homepage ${HOMEPAGE}
+        env:
+          GITHUB_TOKEN: ${{ secrets.DOCS_TOKEN }}
+  

--- a/.github/workflows/publish-00-docs-to-github-pages-setup.yml
+++ b/.github/workflows/publish-00-docs-to-github-pages-setup.yml
@@ -1,9 +1,7 @@
 
 name: Publish 00 docs create repos
 on: 
-  pull_request:
-    branches:
-      - main
+  workflow_dispatch:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-00-docs-to-github-pages-setup.yml
+++ b/.github/workflows/publish-00-docs-to-github-pages-setup.yml
@@ -19,10 +19,8 @@ jobs:
           OWNER=${{ github.repository_owner }}
           REPOSITORY=${OWNER_PLUS_REPOSITORY/$OWNER\//}
           HOMEPAGE="https://${OWNER}.github.io/${REPOSITORY}${SUFFIX}"
-          NEW_REPO=${OWNER_PLUS_REPOSITORY}${SUFFIX}
-        
-          gh repo create ${NEW_REPO} --public --description "${DESC}" 
-          gh repo edit ${NEW_REPO} --homepage ${HOMEPAGE}
+          NEW_REPO=${OWNER_PLUS_REPOSITORY}${SUFFIX}        
+          gh repo create ${NEW_REPO} --public --description "${DESC}" --template ${TEMPLATE}
         env:
           GITHUB_TOKEN: ${{ secrets.DOCS_TOKEN }}
       - name: "Set homepage in -docs repo"
@@ -30,8 +28,33 @@ jobs:
         continue-on-error: true
         run: |
           SUFFIX="-docs"
-          DESC="Documentation for ${OWNER_PLUS_REPOSITORY}"
+          OWNER=${{ github.repository_owner }}
+          REPOSITORY=${OWNER_PLUS_REPOSITORY/$OWNER\//}
+          HOMEPAGE="https://${OWNER}.github.io/${REPOSITORY}${SUFFIX}"
+          NEW_REPO=${OWNER_PLUS_REPOSITORY}${SUFFIX}
+          gh repo edit ${NEW_REPO} --homepage ${HOMEPAGE}
+        env:
+          GITHUB_TOKEN: ${{ secrets.DOCS_TOKEN }}
+      - name: "Create -docs-qa repo"
+        working-directory: .
+        continue-on-error: true
+        run: |
+          SUFFIX="-docs-qa"
+          DESC="Documentation QA site for ${OWNER_PLUS_REPOSITORY}"
           TEMPLATE="https://github.com/ucsb-cs156-w22/TEMPLATE-docs"
+          OWNER_PLUS_REPOSITORY=${{github.repository}}
+          OWNER=${{ github.repository_owner }}
+          REPOSITORY=${OWNER_PLUS_REPOSITORY/$OWNER\//}
+          HOMEPAGE="https://${OWNER}.github.io/${REPOSITORY}${SUFFIX}"
+          NEW_REPO=${OWNER_PLUS_REPOSITORY}${SUFFIX}        
+          gh repo create ${NEW_REPO} --public --description "${DESC}" --template ${TEMPLATE}
+        env:
+          GITHUB_TOKEN: ${{ secrets.DOCS_TOKEN }}
+      - name: "Set homepage in -docs-qa repo"
+        working-directory: .
+        continue-on-error: true
+        run: |
+          SUFFIX="-docs-qa"
           OWNER_PLUS_REPOSITORY=${{github.repository}}
           OWNER=${{ github.repository_owner }}
           REPOSITORY=${OWNER_PLUS_REPOSITORY/$OWNER\//}
@@ -40,4 +63,4 @@ jobs:
           gh repo edit ${NEW_REPO} --homepage ${HOMEPAGE}
         env:
           GITHUB_TOKEN: ${{ secrets.DOCS_TOKEN }}
-  
+   

--- a/.github/workflows/publish-00-docs-to-github-pages-setup.yml
+++ b/.github/workflows/publish-00-docs-to-github-pages-setup.yml
@@ -1,0 +1,38 @@
+
+name: Publish 00 docs create repos
+  push:
+    branches:
+      - pc-improve-docs-repo-setup
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create -docs repo
+          working-directory: .
+        run: |
+          OWNER_PLUS_REPOSITORY=${{github.repository}}
+          OWNER=${{ github.repository_owner }}
+          REPOSITORY=${OWNER_PLUS_REPOSITORY/$OWNER\//}
+          HOMEPAGE="https://${OWNER}.github.io/${REPOSITORY}${SUFFIX}"
+          NEW_REPO=${OWNER_PLUS_REPOSITORY}${SUFFIX}
+          SUFFIX="-docs"
+          DESC="Documentation for ${OWNER_PLUS_REPOSITORY}"
+          gh repo create ${NEW_REPO} --public --description ${DESC} --homepage ${HOMEPAGE}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create -docs-qa repo
+          working-directory: .
+        run: |
+          OWNER_PLUS_REPOSITORY=${{github.repository}}
+          OWNER=${{ github.repository_owner }}
+          REPOSITORY=${OWNER_PLUS_REPOSITORY/$OWNER\//}
+          HOMEPAGE="https://${OWNER}.github.io/${REPOSITORY}${SUFFIX}"
+          NEW_REPO=${OWNER_PLUS_REPOSITORY}${SUFFIX}
+          SUFFIX="-docs-qa"
+          DESC="Documentation for QA site for ${OWNER_PLUS_REPOSITORY}"
+          gh repo create ${NEW_REPO} --public --description ${DESC} --homepage ${HOMEPAGE}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        env: 
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    


### PR DESCRIPTION
# Overview

In this PR, we add a GitHub Actions script that will automatically set up the two auxiliary repos for the documentation sites: 

* owner/repo-docs
* owner/repo-docs-qa

The script:
* Creates the repos if they don't already exist
* Sets the description and homepage
* Does an initial commit to create the main branch and docs subdirectories
* Sets up GitHub pages.

