### PR TITLE
pc - fix typo in github action for prod docs

### DIFF
--- a/.github/workflows/publish-02-docs-to-github-pages.yml
+++ b/.github/workflows/publish-02-docs-to-github-pages.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Append name of site to _config.yml
-        working-directory: ./frontend/docs-qa-index
+        working-directory: ./frontend/docs-index
         run: | 
           OWNER_PLUS_REPOSITORY=${{github.repository}}
           OWNER=${{ github.repository_owner }}


### PR DESCRIPTION
# Overview

This PR fixes a typo in the github work flow for producing the production Storybook.

The typo resulted in the qa version of the index.md file being published instead of the regular one.