### PR TITLE
pc - added scaffolding for todos and updated frontend test coverage

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -2,6 +2,10 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 import HomePage from "main/pages/HomePage";
 import ProfilePage from "main/pages/ProfilePage";
 import AdminUsersPage from "main/pages/AdminUsersPage";
+import TodosIndexPage from "main/pages/Todos/TodosIndexPage";
+import TodosCreatePage from "main/pages/Todos/TodosCreatePage";
+import TodosEditPage from "main/pages/Todos/TodosEditPage";
+
 import { hasRole, useCurrentUser } from "main/utils/currentUser";
 
 import "bootstrap/dist/css/bootstrap.css";
@@ -12,15 +16,24 @@ function App() {
   const { data: currentUser } = useCurrentUser();
 
   return (
-      <BrowserRouter>
-        <Routes>
-          <Route path="/" element={<HomePage />} />
-          <Route path="/profile" element={<ProfilePage />} />
-          {
-            hasRole(currentUser, "ROLE_ADMIN") && <Route path="/admin/users" element={<AdminUsersPage />} />
-          }
-        </Routes>
-      </BrowserRouter>
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<HomePage />} />
+        <Route path="/profile" element={<ProfilePage />} />
+        {
+          hasRole(currentUser, "ROLE_ADMIN") && <Route path="/admin/users" element={<AdminUsersPage />} />
+        }
+        {
+          hasRole(currentUser, "ROLE_USER") && (
+            <>
+              <Route path="/todos/list" element={<TodosIndexPage />} />
+              <Route path="/todos/create" element={<TodosCreatePage />} />
+              <Route path="/todos/edit/:todoId" element={<TodosEditPage />} />
+            </>
+          )
+        }
+      </Routes>
+    </BrowserRouter>
   );
 }
 

--- a/frontend/src/fixtures/systemInfoFixtures.js
+++ b/frontend/src/fixtures/systemInfoFixtures.js
@@ -1,0 +1,16 @@
+const systemInfoFixtures = {
+    showingBoth:
+    {
+        "springH2ConsoleEnabled": true,
+        "showSwaggerUILink": true
+    },
+    showingNeither:
+    {
+        "springH2ConsoleEnabled": false,
+        "showSwaggerUILink": false
+    }
+};
+
+
+
+export { systemInfoFixtures };

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -3,7 +3,6 @@ import { Link } from "react-router-dom";
 import { hasRole} from "main/utils/currentUser";
 
 export default function AppNavbar({currentUser, systemInfo, doLogout}) { 
-  console.log("systemInfo",systemInfo);
   return (
     <Navbar expand="xl" variant="dark" bg="dark" sticky="top">
       <Container>
@@ -24,6 +23,21 @@ export default function AppNavbar({currentUser, systemInfo, doLogout}) {
             }
           </Nav>
 
+          <>
+           {/* be sure that each NavDropdown has a unique id and data-testid  */}
+          </>
+
+          <Nav className="mr-auto">
+            {
+              hasRole(currentUser,"ROLE_USER") && (
+                <NavDropdown title="Todos" id="appnavbar-todos-dropdown" data-testid="appnavbar-todos-dropdown" >
+                  <NavDropdown.Item href="/todos/list">List Todos</NavDropdown.Item>
+                  <NavDropdown.Item href="/todos/create">Create Todo</NavDropdown.Item>
+                </NavDropdown>
+              )
+            }
+          </Nav>
+
           <Nav className="me-auto">
             {
               systemInfo?.springH2ConsoleEnabled && (
@@ -33,7 +47,7 @@ export default function AppNavbar({currentUser, systemInfo, doLogout}) {
               ) 
             }
             {
-              systemInfo && systemInfo?.showSwaggerUILink && (
+              systemInfo?.showSwaggerUILink && (
                 <>
                    <Nav.Link href="/swagger-ui/index.html">Swagger</Nav.Link>
                 </>

--- a/frontend/src/main/pages/Todos/TodosCreatePage.js
+++ b/frontend/src/main/pages/Todos/TodosCreatePage.js
@@ -1,0 +1,14 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function TodosCreatePage() {
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Todos</h1>
+        <p>
+          This is where the create page will go
+        </p>
+      </div>
+    </BasicLayout>
+  )
+}

--- a/frontend/src/main/pages/Todos/TodosEditPage.js
+++ b/frontend/src/main/pages/Todos/TodosEditPage.js
@@ -1,0 +1,14 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function TodosEditPage() {
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Todos</h1>
+        <p>
+          This is where the edit page will go
+        </p>
+      </div>
+    </BasicLayout>
+  )
+}

--- a/frontend/src/main/pages/Todos/TodosIndexPage.js
+++ b/frontend/src/main/pages/Todos/TodosIndexPage.js
@@ -1,0 +1,14 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function TodosIndexPage() {
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Todos</h1>
+        <p>
+          This is where the index page will go
+        </p>
+      </div>
+    </BasicLayout>
+  )
+}

--- a/frontend/src/main/utils/systemInfo.js
+++ b/frontend/src/main/utils/systemInfo.js
@@ -9,10 +9,17 @@ export function useSystemInfo() {
       return response.data;
     } catch (e) {
       console.error("Error invoking axios.get: ", e);
-      return { error: true};
+      return {  
+        springH2ConsoleEnabled: false,
+        showSwaggerUILink: false  
+      };
     }
   }, {
-    initialData: { initialData:true }
+    initialData: { 
+      initialData:true, 
+      springH2ConsoleEnabled: false,
+      showSwaggerUILink: false 
+    }
   });
 
 }

--- a/frontend/src/tests/components/Nav/AppNavbar.test.js
+++ b/frontend/src/tests/components/Nav/AppNavbar.test.js
@@ -51,7 +51,7 @@ describe("AppNavbar tests", () => {
 
         const doLogin = jest.fn();
 
-        const { getByText , getByTestId } = render(
+        const { getByText  } = render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
                     <AppNavbar currentUser={currentUser} systemInfo={systemInfo} doLogin={doLogin} />
@@ -72,7 +72,7 @@ describe("AppNavbar tests", () => {
 
         const doLogin = jest.fn();
 
-        const { getByText , getByTestId } = render(
+        const {getByTestId } = render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
                     <AppNavbar currentUser={currentUser} systemInfo={systemInfo} doLogin={doLogin} />

--- a/frontend/src/tests/components/Nav/AppNavbar.test.js
+++ b/frontend/src/tests/components/Nav/AppNavbar.test.js
@@ -4,6 +4,7 @@ import { MemoryRouter } from "react-router-dom";
 import { currentUserFixtures } from "fixtures/currentUserFixtures";
 
 import AppNavbar from "main/components/Nav/AppNavbar";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 
 describe("AppNavbar tests", () => {
 
@@ -42,6 +43,46 @@ describe("AppNavbar tests", () => {
         const adminMenu = getByTestId("appnavbar-admin-dropdown");
         expect(adminMenu).toBeInTheDocument();        
     });
+
+    test("renders H2Console and Swagger links correctly", async () => {
+
+        const currentUser = currentUserFixtures.adminUser;
+        const systemInfo = systemInfoFixtures.showingBoth;
+
+        const doLogin = jest.fn();
+
+        const { getByText , getByTestId } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AppNavbar currentUser={currentUser} systemInfo={systemInfo} doLogin={doLogin} />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => expect(getByText("H2Console")).toBeInTheDocument());
+        const swaggerMenu = getByText("Swagger");
+        expect(swaggerMenu).toBeInTheDocument();        
+    });
+
+
+    test("renders the todos menu correctly", async () => {
+
+        const currentUser = currentUserFixtures.userOnly;
+        const systemInfo = systemInfoFixtures.showingBoth;
+
+        const doLogin = jest.fn();
+
+        const { getByText , getByTestId } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AppNavbar currentUser={currentUser} systemInfo={systemInfo} doLogin={doLogin} />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => expect(getByTestId("appnavbar-todos-dropdown")).toBeInTheDocument());
+    });
+
 });
 
 

--- a/frontend/src/tests/pages/AdminUsersPage.test.js
+++ b/frontend/src/tests/pages/AdminUsersPage.test.js
@@ -4,6 +4,8 @@ import { MemoryRouter } from "react-router-dom";
 import AdminUsersPage from "main/pages/AdminUsersPage";
 import usersFixtures from "fixtures/usersFixtures";
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+
 import nock from "nock";
 
 describe("AdminUsersPage tests",  () => {
@@ -11,10 +13,14 @@ describe("AdminUsersPage tests",  () => {
     test("renders without crashing on two users", async () => {
 
         const _expectation1 = nock('http://localhost')
+        .get('/api/systemInfo')
+        .reply(200, systemInfoFixtures.showBoth);
+
+        const _expectation2 = nock('http://localhost')
         .get('/api/currentUser')
         .reply(200, apiCurrentUserFixtures.adminUser);
 
-        const _expectation2 = nock('http://localhost')
+        const _expectation3 = nock('http://localhost')
             .get('/api/admin/users')
             .reply(200, usersFixtures.threeUsers);
 

--- a/frontend/src/tests/pages/Todos/TodosCreatePage.test.js
+++ b/frontend/src/tests/pages/Todos/TodosCreatePage.test.js
@@ -1,0 +1,21 @@
+import { render } from "@testing-library/react";
+import TodosCreatePage from "main/pages/Todos/TodosCreatePage";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+describe("TodosCreatePage tests", () => {
+
+    const queryClient = new QueryClient();
+    test("renders without crashing", () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <TodosCreatePage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+    });
+
+});
+
+

--- a/frontend/src/tests/pages/Todos/TodosEditPage.test.js
+++ b/frontend/src/tests/pages/Todos/TodosEditPage.test.js
@@ -1,0 +1,22 @@
+import { render } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import TodosEditPage from "main/pages/Todos/TodosEditPage";
+
+
+describe("TodosCreatePage tests", () => {
+
+    const queryClient = new QueryClient();
+    test("renders without crashing", () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <TodosEditPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+    });
+
+});
+
+

--- a/frontend/src/tests/pages/Todos/TodosIndexPage.test.js
+++ b/frontend/src/tests/pages/Todos/TodosIndexPage.test.js
@@ -1,0 +1,22 @@
+import { render } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import TodosIndexPage from "main/pages/Todos/TodosIndexPage";
+
+
+describe("TodosIndexPage tests", () => {
+
+    const queryClient = new QueryClient();
+    test("renders without crashing", () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <TodosIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+    });
+
+});
+
+

--- a/frontend/src/tests/utils/systemInfo.test.js
+++ b/frontend/src/tests/utils/systemInfo.test.js
@@ -1,0 +1,102 @@
+import { QueryClient, QueryClientProvider } from "react-query";
+import { useSystemInfo } from "main/utils/systemInfo";
+import { renderHook } from '@testing-library/react-hooks'
+import mockConsole from "jest-mock-console";
+import { act } from 'react-dom/test-utils';
+import { useNavigate } from "react-router-dom"
+
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+
+jest.mock('react-router-dom');
+const { MemoryRouter } = jest.requireActual('react-router-dom');
+
+describe("utils/systemInfo tests", () => {
+    describe("useSystemInfo tests", () => {
+        test("test useSystemInfo retrieves initial data ", async () => {
+            const queryClient = new QueryClient();
+            const wrapper = ({ children }) => (
+                <QueryClientProvider client={queryClient}>
+                    {children}
+                </QueryClientProvider>
+            );
+
+            var axiosMock = new AxiosMockAdapter(axios);
+            axiosMock.onGet("/api/systemInfo").timeoutOnce();
+
+            const restoreConsole = mockConsole();
+
+            const { result, waitFor } = renderHook(() => useSystemInfo(), { wrapper });
+            await waitFor(() => result.current.isSuccess);
+
+            expect(result.current.data).toEqual({ 
+                initialData:true,   
+                springH2ConsoleEnabled: false,
+                showSwaggerUILink: false  
+            });
+            
+            const queryState = queryClient.getQueryState("systemInfo");
+            expect(queryState).toBeDefined();
+
+            queryClient.clear();
+
+            await waitFor( ()=> expect(console.error).toHaveBeenCalled() );
+            const errorMessage = console.error.mock.calls[0][0];
+            expect(errorMessage).toMatch(/Error invoking axios.get:/);
+            restoreConsole();
+        });
+
+        test("test useSystemInfo retrieves data from API ", async () => {
+
+            const queryClient = new QueryClient();
+            const wrapper = ({ children }) => (
+                <QueryClientProvider client={queryClient}>
+                    {children}
+                </QueryClientProvider>
+            );
+
+            var axiosMock = new AxiosMockAdapter(axios);
+            axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingBoth);
+
+            const { result, waitFor } = renderHook(() => useSystemInfo(), { wrapper });
+
+            await waitFor(() => result.current.isFetched);
+           
+
+            expect(result.current.data).toEqual(systemInfoFixtures.showingBoth);
+            queryClient.clear();
+
+        });
+
+        test("test systemInfo when API unreachable ", async () => {
+
+            const queryClient = new QueryClient();
+            const wrapper = ({ children }) => (
+                <QueryClientProvider client={queryClient}>
+                    {children}
+                </QueryClientProvider>
+            );
+
+            var axiosMock = new AxiosMockAdapter(axios);
+            axiosMock.onGet("/api/systemInfo").reply(404)
+
+            const restoreConsole = mockConsole();
+            const { result, waitFor } = renderHook(() => useSystemInfo(), { wrapper });
+
+            await waitFor(() => result.current.isFetched);
+            expect(console.error).toHaveBeenCalled();
+            const errorMessage = console.error.mock.calls[0][0];
+            expect(errorMessage).toMatch(/Error invoking axios.get:/);
+            restoreConsole();
+
+            expect(result.current.data).toEqual({  
+                springH2ConsoleEnabled: false,
+                showSwaggerUILink: false 
+            });
+            queryClient.clear();
+        });
+
+
+    });
+});

--- a/frontend/src/tests/utils/systemInfo.test.js
+++ b/frontend/src/tests/utils/systemInfo.test.js
@@ -2,15 +2,13 @@ import { QueryClient, QueryClientProvider } from "react-query";
 import { useSystemInfo } from "main/utils/systemInfo";
 import { renderHook } from '@testing-library/react-hooks'
 import mockConsole from "jest-mock-console";
-import { act } from 'react-dom/test-utils';
-import { useNavigate } from "react-router-dom"
 
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 
 jest.mock('react-router-dom');
-const { MemoryRouter } = jest.requireActual('react-router-dom');
+const { _MemoryRouter } = jest.requireActual('react-router-dom');
 
 describe("utils/systemInfo tests", () => {
     describe("useSystemInfo tests", () => {


### PR DESCRIPTION
# Overview

In this PR, we add scaffolding for a set of front end pages for CRUD operations for TODOs.   

This PR does NOT contain the actual code for the CRUD operations; it only contains:
* the navigation bar changes
* place holder pages 
* place holder tests for those pages

There is also a small bit of cleanup of front end tests from unrelated frontend code that was already merged without sufficient test coverage; this commit gets us back to 100% test coverage both from jest and stryker.

Still to be done and NOT in this PR:
* component to list todos
* component for creating todos
* component for editing tods
* wiring the front end to the backend


