### PR TITLE
Add MongoDB examples to the code base

### DIFF
--- a/.env.SAMPLE
+++ b/.env.SAMPLE
@@ -1,3 +1,4 @@
 GOOGLE_CLIENT_ID=see-instructions-in-readme
 GOOGLE_CLIENT_SECRET=see-instructions-in-readme
 ADMIN_EMAILS=phtcon@ucsb.edu
+MONGODB_URI=see-instructions-in-readme

--- a/docs/mongodb.md
+++ b/docs/mongodb.md
@@ -1,0 +1,22 @@
+ # Configuring for MongoDB
+
+ In the file `.env.SAMPLE` you'll find the variable `MONGODB_URI`:
+
+ ```text
+MONGODB_URI=see-instructions-in-readme
+ ```
+
+
+ After copying this to `.env`, you should change the value in `.env` (leave `.env.SAMPLE` unmodified!) from `see-instructions-in-readme` to a MongoDB connection URL such as this.  
+ 
+ Note that a real string will have a different value for `usernameGoesHere`, `passwordGoesHere`,  `abcde`, and possibly for `database`.
+
+```
+mongodb+srv://usernameGoesHere:passwordGoesHere@cluster0.abcde.mongodb.net/database?retryWrites=true&w=majority
+```
+
+For information on where to get the MongoDB URL string, consult the MongoDB 
+documentation on the course website: <https://ucsb-cs156.github.io/topics/mongodb/>
+ 
+Note that the application will at least start up with fake values for the username, password, and database, but if the host in the URI does not exist, you
+may get a fatal error on startup (i.e. at the `mvn spring-boot:run` stage.)

--- a/pom.xml
+++ b/pom.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+    <!-- https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-parent -->
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.2</version>
+        <version>2.6.3</version>
         <relativePath /> <!-- lookup parent from repository -->
     </parent>
     <groupId>edu.ucsb.cs156</groupId>
@@ -32,6 +33,13 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
+
+        <!-- https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-data-mongodb -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-mongodb</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-gateway-mvc</artifactId>
@@ -139,48 +147,46 @@
                 <artifactId>pitest-maven</artifactId>
                 <version>1.7.3</version>
                 <dependencies>
-                  <dependency>
-                    <groupId>org.pitest</groupId>
-                    <artifactId>pitest-junit5-plugin</artifactId>
-                    <version>0.14</version>
-                  </dependency>
+                    <dependency>
+                        <groupId>org.pitest</groupId>
+                        <artifactId>pitest-junit5-plugin</artifactId>
+                        <version>0.14</version>
+                    </dependency>
                 </dependencies>
                 <configuration>
-                  <verbose>true</verbose>
-                  <targetClasses>
-                    <param>edu.ucsb.cs156.*</param>
-                  </targetClasses>
-                  <targetTests>
-                    <param>edu.ucsb.cs156.*</param>
-                  </targetTests>
-                  <excludedClasses>
-                    <param>edu.ucsb.cs156.example.services.LoggingService</param>
-                    <param>edu.ucsb.cs156.example.controllers.FrontendController</param>
-                    <param>edu.ucsb.cs156.example.controllers.FrontendProxyController</param>
-                    <param>edu.ucsb.cs156.example.services.CurrentUserServiceImpl</param>
-                    <param>edu.ucsb.cs156.example.ExampleApplication</param>
-                    <param>edu.ucsb.cs156.example.config.SecurityConfig</param>
-                    <param>edu.ucsb.cs156.example.config.SecurityConfig.MyCsrfRequestMatcher</param>
-                    <param>edu.ucsb.cs156.example.config.SpringFoxConfig</param>
-                  </excludedClasses>
-                  <excludedTestClasses>
-                   
-                  </excludedTestClasses>
-                  <outputFormats>
-                    <outputFormat>HTML</outputFormat>
-                    <outputFormat>CSV</outputFormat>
-                    <outputFormat>XML</outputFormat>
-                  </outputFormats>
-                  <avoidCallsTo>
-                    <avoidCallsTo>java.util.logging</avoidCallsTo>
-                    <avoidCallsTo>org.apache.log4j</avoidCallsTo>
-                    <avoidCallsTo>org.slf4j</avoidCallsTo>
-                    <avoidCallsTo>org.apache.commons.logging</avoidCallsTo>
-                    <avoidCallsTo>edu.ucsb.cs156.example.services.LoggingService</avoidCallsTo>
-                  </avoidCallsTo>
-                  <timestampedReports>false</timestampedReports>
+                    <verbose>true</verbose>
+                    <targetClasses>
+                        <param>edu.ucsb.cs156.*</param>
+                    </targetClasses>
+                    <targetTests>
+                        <param>edu.ucsb.cs156.*</param>
+                    </targetTests>
+                    <excludedClasses>
+                        <param>edu.ucsb.cs156.example.services.LoggingService</param>
+                        <param>edu.ucsb.cs156.example.controllers.FrontendController</param>
+                        <param>edu.ucsb.cs156.example.controllers.FrontendProxyController</param>
+                        <param>edu.ucsb.cs156.example.services.CurrentUserServiceImpl</param>
+                        <param>edu.ucsb.cs156.example.ExampleApplication</param>
+                        <param>edu.ucsb.cs156.example.config.SecurityConfig</param>
+                        <param>edu.ucsb.cs156.example.config.SecurityConfig.MyCsrfRequestMatcher</param>
+                        <param>edu.ucsb.cs156.example.config.SpringFoxConfig</param>
+                    </excludedClasses>
+                    <excludedTestClasses></excludedTestClasses>
+                    <outputFormats>
+                        <outputFormat>HTML</outputFormat>
+                        <outputFormat>CSV</outputFormat>
+                        <outputFormat>XML</outputFormat>
+                    </outputFormats>
+                    <avoidCallsTo>
+                        <avoidCallsTo>java.util.logging</avoidCallsTo>
+                        <avoidCallsTo>org.apache.log4j</avoidCallsTo>
+                        <avoidCallsTo>org.slf4j</avoidCallsTo>
+                        <avoidCallsTo>org.apache.commons.logging</avoidCallsTo>
+                        <avoidCallsTo>edu.ucsb.cs156.example.services.LoggingService</avoidCallsTo>
+                    </avoidCallsTo>
+                    <timestampedReports>false</timestampedReports>
                 </configuration>
-              </plugin>
+            </plugin>
 
 
         </plugins>

--- a/src/main/java/edu/ucsb/cs156/example/collections/StudentCollection.java
+++ b/src/main/java/edu/ucsb/cs156/example/collections/StudentCollection.java
@@ -1,0 +1,15 @@
+package edu.ucsb.cs156.example.collections;
+
+import java.util.Optional;
+
+import org.bson.types.ObjectId;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+import edu.ucsb.cs156.example.documents.Student;
+
+@Repository
+public interface StudentCollection extends MongoRepository<Student, ObjectId> {
+  Optional<Student> findOneByPerm(int perm);
+  Optional<Student> findOneByFirstNameAndLastName(String firstName, String lastName);
+}

--- a/src/main/java/edu/ucsb/cs156/example/controllers/FrontendProxyController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/FrontendProxyController.java
@@ -19,7 +19,15 @@ public class FrontendProxyController {
       return proxy.uri("http://localhost:3000/" + path).get();
     } catch (ResourceAccessException e) {
       if (e.getCause() instanceof ConnectException) {
-        String instructions = "Failed to connect to the frontend server... On Heroku, be sure that PRODUCTION is defined.  On localhost, open a second terminal window, cd into frontend and type: npm install; npm start";
+        String instructions = "<p>Failed to connect to the frontend server...</p>";
+        instructions += "<p>On Heroku, be sure that <code>PRODUCTION</code> is defined.</p>";
+        instructions += "<p>On localhost, open a second terminal window, cd into <code>frontend</code> and type: <code>npm install; npm start</code></p>";
+        instructions += "<p>Or, you may click to access: </p>";
+        instructions += "<ul>";
+        instructions += "<li><a href='/swagger-ui/index.html'>/swagger-ui/index.html</a></li>";
+        instructions += "<li><a href='/h2-console'>/h2-console</a></li>";
+        instructions += "</ul>";
+
         return ResponseEntity.ok(instructions);
       }
       throw e;

--- a/src/main/java/edu/ucsb/cs156/example/controllers/FrontendProxyController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/FrontendProxyController.java
@@ -19,14 +19,15 @@ public class FrontendProxyController {
       return proxy.uri("http://localhost:3000/" + path).get();
     } catch (ResourceAccessException e) {
       if (e.getCause() instanceof ConnectException) {
-        String instructions = "<p>Failed to connect to the frontend server...</p>";
-        instructions += "<p>On Heroku, be sure that <code>PRODUCTION</code> is defined.</p>";
-        instructions += "<p>On localhost, open a second terminal window, cd into <code>frontend</code> and type: <code>npm install; npm start</code></p>";
-        instructions += "<p>Or, you may click to access: </p>";
-        instructions += "<ul>";
-        instructions += "<li><a href='/swagger-ui/index.html'>/swagger-ui/index.html</a></li>";
-        instructions += "<li><a href='/h2-console'>/h2-console</a></li>";
-        instructions += "</ul>";
+        String instructions = """
+                <p>Failed to connect to the frontend server...</p>
+                <p>On Heroku, be sure that <code>PRODUCTION</code> is defined.</p>
+                <p>On localhost, open a second terminal window, cd into <code>frontend</code> and type: <code>npm install; npm start</code></p>
+                <p>Or, you may click to access: </p>
+                <ul>
+                  <li><a href='/swagger-ui/index.html'>/swagger-ui/index.html</a></li>
+                  <li><a href='/h2-console'>/h2-console</a></li>
+                </ul>""";
 
         return ResponseEntity.ok(instructions);
       }

--- a/src/main/java/edu/ucsb/cs156/example/controllers/StudentsController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/StudentsController.java
@@ -1,0 +1,70 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.collections.StudentCollection;
+import edu.ucsb.cs156.example.documents.Student;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import lombok.extern.slf4j.Slf4j;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@Api(description = "Students")
+@RequestMapping("/api/students")
+@RestController
+@Slf4j
+public class StudentsController extends ApiController {
+
+    @Autowired
+    StudentCollection studentCollection;
+
+    @Autowired
+    ObjectMapper mapper;
+
+    @ApiOperation(value = "List all students")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/all")
+    public Iterable<Student> allStudents() {
+        loggingService.logMethod();
+        Iterable<Student> students = studentCollection.findAll();
+        return students;
+    }
+
+    @ApiOperation(value = "Add a Student to the collection")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @PostMapping("/post")
+    public Student postStudent(
+            @ApiParam("firstName") @RequestParam String firstName,
+            @ApiParam("lastName") @RequestParam String lastName,
+            @ApiParam("perm") @RequestParam int perm) {
+        loggingService.logMethod();
+
+        Student student = new Student();
+        student.setFirstName(firstName);
+        student.setLastName(lastName);
+        student.setPerm(perm);
+
+        // OR
+
+        // Student student = Student.builder()
+        //         .firstName(firstName)
+        //         .lastName(lastName)
+        //         .perm(perm)
+        //         .build();
+
+        Student savedStudent = studentCollection.save(student);
+        return savedStudent;
+    }
+
+}

--- a/src/main/java/edu/ucsb/cs156/example/documents/Student.java
+++ b/src/main/java/edu/ucsb/cs156/example/documents/Student.java
@@ -1,0 +1,24 @@
+package edu.ucsb.cs156.example.documents;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Document(collection = "students")
+public class Student {
+    @Id
+    private String id;
+
+    private String firstName;
+    private String lastName;
+    private int perm;
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -22,3 +22,5 @@ app.admin.emails=${ADMIN_EMAILS:${env.ADMIN_EMAILS:phtcon@ucsb.edu}}
 spring.mvc.pathmatch.matching-strategy = ANT_PATH_MATCHER
 server.compression.enabled=false
 
+spring.data.mongodb.uri=${MONGODB_URI:${env.MONGODB_URI:mongodb+srv://fakeUsername:fakePassword@cluster0.ulqcw.mongodb.net/fakeDatabase?retryWrites=true&w=majority}}
+

--- a/src/test/java/edu/ucsb/cs156/example/controllers/StudentsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/StudentsControllerTests.java
@@ -1,0 +1,119 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.collections.StudentCollection;
+import edu.ucsb.cs156.example.documents.Student;
+import edu.ucsb.cs156.example.entities.Todo;
+import edu.ucsb.cs156.example.entities.User;
+import edu.ucsb.cs156.example.repositories.TodoRepository;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Optional;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@WebMvcTest(controllers = StudentsController.class)
+@Import(TestConfig.class)
+public class StudentsControllerTests extends ControllerTestCase {
+
+        @MockBean
+        StudentCollection studentCollection;
+
+        @MockBean
+        UserRepository userRepository;
+
+        // Authorization tests for /api/students/all
+
+        @Test
+        public void api_students_all__logged_out__returns_403() throws Exception {
+                mockMvc.perform(get("/api/students/all"))
+                                .andExpect(status().is(403));
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void api_students_all__user_logged_in__returns_ok() throws Exception {
+                mockMvc.perform(get("/api/students/all"))
+                                .andExpect(status().isOk());
+        }
+
+        // Authorization tests for /api/students/post
+
+        @Test
+        public void api_students_post__logged_out__returns_403() throws Exception {
+                mockMvc.perform(post("/api/students/post"))
+                                .andExpect(status().is(403));
+        }
+
+        // Tests with mocks for database actions
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void api_students_all__user_logged_in__returns_a_student_that_exists() throws Exception {
+
+                // arrange
+
+                Student s = Student.builder().perm(1234567).firstName("Chris").lastName("Gaucho").id("7").build();
+                ArrayList<Student> students = new ArrayList<>();
+                when(studentCollection.findAll()).thenReturn(students);
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/students/all"))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+
+                verify(studentCollection, times(1)).findAll();
+                String expectedJson = mapper.writeValueAsString(students);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+        // Tests with mocks for database actions
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void api_students_post__user_logged_in__creates_a_student() throws Exception {
+
+                Student expectedStudent = Student.builder()
+                                .perm(1234567)
+                                .firstName("Chris")
+                                .lastName("Gaucho")
+                                .build();
+
+                when(studentCollection.save(eq(expectedStudent))).thenReturn(expectedStudent);
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                post("/api/students/post?perm=1234567&firstName=Chris&lastName=Gaucho")
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(studentCollection, times(1)).save(expectedStudent);
+                String expectedJson = mapper.writeValueAsString(expectedStudent);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+
+        }
+
+}


### PR DESCRIPTION
# Overview

In this  PR, we add MongoDB examples to the code base.

We've added:
* `MONGODB_URI=see-instructions-in-readme` in `.env.SAMPLE` along with the appropriate properties in `application.properties`
*  A new file of instructions, `docs/mongodb.md`
* The dependency in the `pom.xml`
* A sample document class, `Student.java`
* A sample collection class `StudentCollection.java`
* A controller example with endpoints `GET /api/students/all` and `POST /api/students/post?perm=1234556&firstName=Chris&lastName=Gaucho`
* Controller tests

And unrelated change in `FrontendProxyController.java` provides a nicer message on the home page when
the backend is started up without the frontend.

