### PR TITLE
pc - add timeout and make docs and docs-qa workflow_dispatch

### DIFF
--- a/.github/workflows/backend-01-unit.yml
+++ b/.github/workflows/backend-01-unit.yml
@@ -11,9 +11,9 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
+    timeout-minutes: 10
+    
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK 17

--- a/.github/workflows/backend-02-jacoco.yml
+++ b/.github/workflows/backend-02-jacoco.yml
@@ -13,6 +13,7 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/backend-03-pitest.yml
+++ b/.github/workflows/backend-03-pitest.yml
@@ -13,6 +13,7 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/frontend-00-eslint.yml
+++ b/.github/workflows/frontend-00-eslint.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+
     strategy:
       matrix:
         node-version: [14.x]

--- a/.github/workflows/frontend-01-tests.yml
+++ b/.github/workflows/frontend-01-tests.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+
     strategy:
       matrix:
         node-version: [17.x]

--- a/.github/workflows/frontend-02-coverage.yml
+++ b/.github/workflows/frontend-02-coverage.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+
     strategy:
       matrix:
         node-version: [17.x]

--- a/.github/workflows/frontend-03-mutation-testing.yml
+++ b/.github/workflows/frontend-03-mutation-testing.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+
     strategy:
       matrix:
         node-version: [17.x]

--- a/.github/workflows/publish-01-docs-to-github-pages-qa.yml
+++ b/.github/workflows/publish-01-docs-to-github-pages-qa.yml
@@ -24,62 +24,62 @@ jobs:
         run: |
           echo 'BRANCH='${{ github.head_ref }} >> $GITHUB_ENV
           echo "\$GIHTHUB_ENV=${GITHUB_ENV}"
-      - name: Append name of site to _config.yml
-        working-directory: ./frontend/docs-qa-index
-        run: | 
-          OWNER_PLUS_REPOSITORY=${{github.repository}}
-          OWNER=${{ github.repository_owner }}
-          REPOSITORY=${OWNER_PLUS_REPOSITORY/$OWNER\//}
-          echo "repo: ${OWNER_PLUS_REPOSITORY}" >> _config.yml
-          echo "owner: ${OWNER}" >> _config.yml
-          echo "repo_name: ${REPOSITORY}" >> _config.yml
-      - name: Deploy index.md and jekyll files for docs-qa site 🚀
-        uses: JamesIves/github-pages-deploy-action@4.2.0
-        with:
-          repository-name: ${{ github.repository }}-docs-qa
-          token: ${{ secrets.DOCS_TOKEN }}
-          branch: main # The branch the action should deploy to.
-          folder: frontend/docs-qa-index 
-          clean: false 
-          target-folder: docs
-      - name: Generate .md file to add to branch collection
-        working-directory: ./frontend
-        run: |           
-          BRANCH_DIR=_branches.tmp
-          mkdir -p $BRANCH_DIR
-          FILENAME=${BRANCH_DIR}/${{env.BRANCH}}.md
-          rm -f $FILENAME
-          touch $FILENAME
-          echo "---" >> $FILENAME
-          echo "name: ${{ env.BRANCH }}" >> $FILENAME
-          echo "actor: ${{ github.actor}}" >> $FILENAME
-          echo "pull_request_url: ${{ github.event.pull_request.html_url}}" >> $FILENAME
-          echo "pull_request_num: ${{ github.event.pull_request.number}}" >> $FILENAME
-          echo "---" >> $FILENAME
-      - name: Pushes branch
-        uses: dmnemec/copy_file_to_another_repo_action@main
-        env:
-          API_TOKEN_GITHUB: ${{ secrets.DOCS_TOKEN }}
-        with:
-          source_file: 'frontend/_branches.tmp/${{ env.BRANCH }}.md'
-          destination_repo: ${{ github.repository }}-docs-qa
-          destination_folder: 'docs/_branches'
-          commit_message: 'Add branch ${{ env.BRANCH }} to docs-qa repo'
-          user_email: phtcon@ucsb.edu
-          user_name: "Phill Conrad, UCSB CS machine user"
-      - name: Install and Build 🔧
-        working-directory: ./frontend
-        run: | # Install npm packages and build the Storybook files
-          npm install
-          mkdir -p storybook-static
-          npm run build-storybook
-      - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@4.2.0
-        with:
-          repository-name: ${{ github.repository }}-docs-qa
-          token: ${{ secrets.DOCS_TOKEN }}
-          branch: main # The branch the action should deploy to.
-          folder: frontend/storybook-static # The folder that the build-storybook script generates files.
-          clean: true # Automatically remove deleted files from the deploy branch
-          target-folder: docs/storybook-qa/${{ env.BRANCH }} # The folder that we serve our Storybook files from 
+      # - name: Append name of site to _config.yml
+      #   working-directory: ./frontend/docs-qa-index
+      #   run: | 
+      #     OWNER_PLUS_REPOSITORY=${{github.repository}}
+      #     OWNER=${{ github.repository_owner }}
+      #     REPOSITORY=${OWNER_PLUS_REPOSITORY/$OWNER\//}
+      #     echo "repo: ${OWNER_PLUS_REPOSITORY}" >> _config.yml
+      #     echo "owner: ${OWNER}" >> _config.yml
+      #     echo "repo_name: ${REPOSITORY}" >> _config.yml
+      # - name: Deploy index.md and jekyll files for docs-qa site 🚀
+      #   uses: JamesIves/github-pages-deploy-action@4.2.0
+      #   with:
+      #     repository-name: ${{ github.repository }}-docs-qa
+      #     token: ${{ secrets.DOCS_TOKEN }}
+      #     branch: main # The branch the action should deploy to.
+      #     folder: frontend/docs-qa-index 
+      #     clean: false 
+      #     target-folder: docs
+      # - name: Generate .md file to add to branch collection
+      #   working-directory: ./frontend
+      #   run: |           
+      #     BRANCH_DIR=_branches.tmp
+      #     mkdir -p $BRANCH_DIR
+      #     FILENAME=${BRANCH_DIR}/${{env.BRANCH}}.md
+      #     rm -f $FILENAME
+      #     touch $FILENAME
+      #     echo "---" >> $FILENAME
+      #     echo "name: ${{ env.BRANCH }}" >> $FILENAME
+      #     echo "actor: ${{ github.actor}}" >> $FILENAME
+      #     echo "pull_request_url: ${{ github.event.pull_request.html_url}}" >> $FILENAME
+      #     echo "pull_request_num: ${{ github.event.pull_request.number}}" >> $FILENAME
+      #     echo "---" >> $FILENAME
+      # - name: Pushes branch
+      #   uses: dmnemec/copy_file_to_another_repo_action@main
+      #   env:
+      #     API_TOKEN_GITHUB: ${{ secrets.DOCS_TOKEN }}
+      #   with:
+      #     source_file: 'frontend/_branches.tmp/${{ env.BRANCH }}.md'
+      #     destination_repo: ${{ github.repository }}-docs-qa
+      #     destination_folder: 'docs/_branches'
+      #     commit_message: 'Add branch ${{ env.BRANCH }} to docs-qa repo'
+      #     user_email: phtcon@ucsb.edu
+      #     user_name: "Phill Conrad, UCSB CS machine user"
+      # - name: Install and Build 🔧
+      #   working-directory: ./frontend
+      #   run: | # Install npm packages and build the Storybook files
+      #     npm install
+      #     mkdir -p storybook-static
+      #     npm run build-storybook
+      # - name: Deploy 🚀
+      #   uses: JamesIves/github-pages-deploy-action@4.2.0
+      #   with:
+      #     repository-name: ${{ github.repository }}-docs-qa
+      #     token: ${{ secrets.DOCS_TOKEN }}
+      #     branch: main # The branch the action should deploy to.
+      #     folder: frontend/storybook-static # The folder that the build-storybook script generates files.
+      #     clean: true # Automatically remove deleted files from the deploy branch
+      #     target-folder: docs/storybook-qa/${{ env.BRANCH }} # The folder that we serve our Storybook files from 
       

--- a/.github/workflows/publish-01-docs-to-github-pages-qa.yml
+++ b/.github/workflows/publish-01-docs-to-github-pages-qa.yml
@@ -1,5 +1,5 @@
 
-name: Publish 01 docs (Storybook) to GitHub Pages QA
+name: 00 Publish 01 docs (Storybook) to GitHub Pages QA
 on: 
   pull_request:
     branches:
@@ -7,6 +7,8 @@ on:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v2.3.1

--- a/.github/workflows/publish-01-docs-to-github-pages-qa.yml
+++ b/.github/workflows/publish-01-docs-to-github-pages-qa.yml
@@ -1,5 +1,5 @@
 
-name: 00 Publish 01 docs (Storybook) to GitHub Pages QA
+name: Publish 01 docs (Storybook) to GitHub Pages QA
 on: 
   pull_request:
     branches:
@@ -7,76 +7,67 @@ on:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v2.3.1
         with:
           persist-credentials: false
-      - name: Set default for branch to the branch this is run on
-        run: |
-          echo 'BRANCH='${{ env.GITHUB_REF }} >> $GITHUB_ENV
-          echo "\$GIHTHUB_ENV=${GITHUB_ENV}"
-      - name: "If this is a PR, get the head branch (branch pulling from)""
-        run: |
-          echo 'BRANCH='${{ github.head_ref }} >> $GITHUB_ENV
-          echo "\$GIHTHUB_ENV=${GITHUB_ENV}"
-      # - name: Append name of site to _config.yml
-      #   working-directory: ./frontend/docs-qa-index
-      #   run: | 
-      #     OWNER_PLUS_REPOSITORY=${{github.repository}}
-      #     OWNER=${{ github.repository_owner }}
-      #     REPOSITORY=${OWNER_PLUS_REPOSITORY/$OWNER\//}
-      #     echo "repo: ${OWNER_PLUS_REPOSITORY}" >> _config.yml
-      #     echo "owner: ${OWNER}" >> _config.yml
-      #     echo "repo_name: ${REPOSITORY}" >> _config.yml
-      # - name: Deploy index.md and jekyll files for docs-qa site 🚀
-      #   uses: JamesIves/github-pages-deploy-action@4.2.0
-      #   with:
-      #     repository-name: ${{ github.repository }}-docs-qa
-      #     token: ${{ secrets.DOCS_TOKEN }}
-      #     branch: main # The branch the action should deploy to.
-      #     folder: frontend/docs-qa-index 
-      #     clean: false 
-      #     target-folder: docs
-      # - name: Generate .md file to add to branch collection
-      #   working-directory: ./frontend
-      #   run: |           
-      #     BRANCH_DIR=_branches.tmp
-      #     mkdir -p $BRANCH_DIR
-      #     FILENAME=${BRANCH_DIR}/${{env.BRANCH}}.md
-      #     rm -f $FILENAME
-      #     touch $FILENAME
-      #     echo "---" >> $FILENAME
-      #     echo "name: ${{ env.BRANCH }}" >> $FILENAME
-      #     echo "actor: ${{ github.actor}}" >> $FILENAME
-      #     echo "pull_request_url: ${{ github.event.pull_request.html_url}}" >> $FILENAME
-      #     echo "pull_request_num: ${{ github.event.pull_request.number}}" >> $FILENAME
-      #     echo "---" >> $FILENAME
-      # - name: Pushes branch
-      #   uses: dmnemec/copy_file_to_another_repo_action@main
-      #   env:
-      #     API_TOKEN_GITHUB: ${{ secrets.DOCS_TOKEN }}
-      #   with:
-      #     source_file: 'frontend/_branches.tmp/${{ env.BRANCH }}.md'
-      #     destination_repo: ${{ github.repository }}-docs-qa
-      #     destination_folder: 'docs/_branches'
-      #     commit_message: 'Add branch ${{ env.BRANCH }} to docs-qa repo'
-      #     user_email: phtcon@ucsb.edu
-      #     user_name: "Phill Conrad, UCSB CS machine user"
-      # - name: Install and Build 🔧
-      #   working-directory: ./frontend
-      #   run: | # Install npm packages and build the Storybook files
-      #     npm install
-      #     mkdir -p storybook-static
-      #     npm run build-storybook
-      # - name: Deploy 🚀
-      #   uses: JamesIves/github-pages-deploy-action@4.2.0
-      #   with:
-      #     repository-name: ${{ github.repository }}-docs-qa
-      #     token: ${{ secrets.DOCS_TOKEN }}
-      #     branch: main # The branch the action should deploy to.
-      #     folder: frontend/storybook-static # The folder that the build-storybook script generates files.
-      #     clean: true # Automatically remove deleted files from the deploy branch
-      #     target-folder: docs/storybook-qa/${{ env.BRANCH }} # The folder that we serve our Storybook files from 
+      - name: Append name of site to _config.yml
+        working-directory: ./frontend/docs-qa-index
+        run: | 
+          OWNER_PLUS_REPOSITORY=${{github.repository}}
+          OWNER=${{ github.repository_owner }}
+          REPOSITORY=${OWNER_PLUS_REPOSITORY/$OWNER\//}
+          echo "repo: ${OWNER_PLUS_REPOSITORY}" >> _config.yml
+          echo "owner: ${OWNER}" >> _config.yml
+          echo "repo_name: ${REPOSITORY}" >> _config.yml
+      - name: Deploy index.md and jekyll files for docs-qa site 🚀
+        uses: JamesIves/github-pages-deploy-action@4.2.0
+        with:
+          repository-name: ${{ github.repository }}-docs-qa
+          token: ${{ secrets.DOCS_TOKEN }}
+          branch: main # The branch the action should deploy to.
+          folder: frontend/docs-qa-index 
+          clean: false 
+          target-folder: docs
+      - name: Generate .md file to add to branch collection
+        working-directory: ./frontend
+        run: | 
+          BRANCH_DIR=_branches.tmp
+          mkdir -p $BRANCH_DIR
+          FILENAME=${BRANCH_DIR}/${{github.head_ref }}.md
+          rm -f $FILENAME
+          touch $FILENAME
+          echo "---" >> $FILENAME
+          echo "name: ${{ github.head_ref }}" >> $FILENAME
+          echo "actor: ${{ github.actor}}" >> $FILENAME
+          echo "pull_request_url: ${{ github.event.pull_request.html_url}}" >> $FILENAME
+          echo "pull_request_num: ${{ github.event.pull_request.number}}" >> $FILENAME
+          echo "---" >> $FILENAME
+      - name: Pushes branch
+        uses: dmnemec/copy_file_to_another_repo_action@main
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.DOCS_TOKEN }}
+        with:
+          source_file: 'frontend/_branches.tmp/${{github.head_ref }}.md'
+          destination_repo: ${{ github.repository }}-docs-qa
+          destination_folder: 'docs/_branches'
+          commit_message: 'Add branch ${{ github.head_ref }} to docs-qa repo'
+          user_email: phtcon@ucsb.edu
+          user_name: "Phill Conrad, UCSB CS machine user"
+      - name: Install and Build 🔧
+        working-directory: ./frontend
+        run: | # Install npm packages and build the Storybook files
+          npm install
+          mkdir -p storybook-static
+          npm run build-storybook
+      - name: Deploy 🚀
+        uses: JamesIves/github-pages-deploy-action@4.2.0
+        with:
+          repository-name: ${{ github.repository }}-docs-qa
+          token: ${{ secrets.DOCS_TOKEN }}
+          branch: main # The branch the action should deploy to.
+          folder: frontend/storybook-static # The folder that the build-storybook script generates files.
+          clean: true # Automatically remove deleted files from the deploy branch
+          target-folder: docs/storybook-qa/${{ github.head_ref}} # The folder that we serve our Storybook files from 
       

--- a/.github/workflows/publish-01-docs-to-github-pages-qa.yml
+++ b/.github/workflows/publish-01-docs-to-github-pages-qa.yml
@@ -1,17 +1,29 @@
 
 name: Publish 01 docs (Storybook) to GitHub Pages QA
 on: 
+  workflow_dispatch:
   pull_request:
     branches:
       - main
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v2.3.1
         with:
           persist-credentials: false
+      - name: Set default for branch to the branch this is run on
+        run: |
+          echo 'BRANCH='${{ env.GITHUB_REF }} >> $GITHUB_ENV
+          echo "\$GIHTHUB_ENV=${GITHUB_ENV}"
+      - name: If this is a PR, get the head branch (branch pulling from)
+        if: ${{ github.head_ref != "" }}
+        run: |
+          echo 'BRANCH='${{ github.head_ref }} >> $GITHUB_ENV
+          echo "\$GIHTHUB_ENV=${GITHUB_ENV}"
       - name: Append name of site to _config.yml
         working-directory: ./frontend/docs-qa-index
         run: | 
@@ -32,14 +44,14 @@ jobs:
           target-folder: docs
       - name: Generate .md file to add to branch collection
         working-directory: ./frontend
-        run: | 
+        run: |           
           BRANCH_DIR=_branches.tmp
           mkdir -p $BRANCH_DIR
-          FILENAME=${BRANCH_DIR}/${{github.head_ref }}.md
+          FILENAME=${BRANCH_DIR}/${{env.BRANCH}}.md
           rm -f $FILENAME
           touch $FILENAME
           echo "---" >> $FILENAME
-          echo "name: ${{ github.head_ref }}" >> $FILENAME
+          echo "name: ${{ env.BRANCH }}" >> $FILENAME
           echo "actor: ${{ github.actor}}" >> $FILENAME
           echo "pull_request_url: ${{ github.event.pull_request.html_url}}" >> $FILENAME
           echo "pull_request_num: ${{ github.event.pull_request.number}}" >> $FILENAME
@@ -49,10 +61,10 @@ jobs:
         env:
           API_TOKEN_GITHUB: ${{ secrets.DOCS_TOKEN }}
         with:
-          source_file: 'frontend/_branches.tmp/${{github.head_ref }}.md'
+          source_file: 'frontend/_branches.tmp/${{ env.BRANCH }}.md'
           destination_repo: ${{ github.repository }}-docs-qa
           destination_folder: 'docs/_branches'
-          commit_message: 'Add branch ${{ github.head_ref }} to docs-qa repo'
+          commit_message: 'Add branch ${{ env.BRANCH }} to docs-qa repo'
           user_email: phtcon@ucsb.edu
           user_name: "Phill Conrad, UCSB CS machine user"
       - name: Install and Build 🔧
@@ -69,5 +81,5 @@ jobs:
           branch: main # The branch the action should deploy to.
           folder: frontend/storybook-static # The folder that the build-storybook script generates files.
           clean: true # Automatically remove deleted files from the deploy branch
-          target-folder: docs/storybook-qa/${{ github.head_ref}} # The folder that we serve our Storybook files from 
+          target-folder: docs/storybook-qa/${{ env.BRANCH }} # The folder that we serve our Storybook files from 
       

--- a/.github/workflows/publish-01-docs-to-github-pages-qa.yml
+++ b/.github/workflows/publish-01-docs-to-github-pages-qa.yml
@@ -1,14 +1,12 @@
 
-name: Publish 01 docs (Storybook) to GitHub Pages QA
+name: 00 Publish 01 docs (Storybook) to GitHub Pages QA
 on: 
-  workflow_dispatch:
   pull_request:
     branches:
       - main
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
 
     steps:
       - name: Checkout 🛎️
@@ -19,8 +17,7 @@ jobs:
         run: |
           echo 'BRANCH='${{ env.GITHUB_REF }} >> $GITHUB_ENV
           echo "\$GIHTHUB_ENV=${GITHUB_ENV}"
-      - name: If this is a PR, get the head branch (branch pulling from)
-        if: ${{ github.head_ref != "" }}
+      - name: "If this is a PR, get the head branch (branch pulling from)""
         run: |
           echo 'BRANCH='${{ github.head_ref }} >> $GITHUB_ENV
           echo "\$GIHTHUB_ENV=${GITHUB_ENV}"

--- a/.github/workflows/publish-01-docs-to-github-pages-qa.yml
+++ b/.github/workflows/publish-01-docs-to-github-pages-qa.yml
@@ -1,6 +1,7 @@
 
 name: 00 Publish 01 docs (Storybook) to GitHub Pages QA
 on: 
+  workflow_dispatch:
   pull_request:
     branches:
       - main

--- a/.github/workflows/publish-01-docs-to-github-pages-qa.yml
+++ b/.github/workflows/publish-01-docs-to-github-pages-qa.yml
@@ -14,6 +14,10 @@ jobs:
         uses: actions/checkout@v2.3.1
         with:
           persist-credentials: false
+      - name: Figure out Branch name
+        run: | 
+          echo GITHUB_HEAD_REF=${GITHUB_HEAD_REF}
+          echo GITHUB_REF=${GITHUB_REF}
       - name: Append name of site to _config.yml
         working-directory: ./frontend/docs-qa-index
         run: | 

--- a/.github/workflows/publish-02-docs-to-github-pages.yml
+++ b/.github/workflows/publish-02-docs-to-github-pages.yml
@@ -1,12 +1,15 @@
 
 name: Publish 02 docs (Storybook) to GitHub Pages
 on: 
+  workflow_dispatch:
   push:
     branches:
       - main
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v2.3.1


### PR DESCRIPTION
# Overview

In this PR, we add timeouts to all Github Actions scripts to avoid overbilling.

We also simplify the setup of the docs repos by adding:

```
on: 
  workflow_dispatch:
```

and for the docs-qa script, setting appropriate defaults for picking the branch when it isn't triggered by a pull request.