### PR TITLE
pc - try to figure out branch name with defaults for workflow_dispatch

### DIFF
--- a/.github/workflows/publish-01-docs-to-github-pages-qa.yml
+++ b/.github/workflows/publish-01-docs-to-github-pages-qa.yml
@@ -23,7 +23,7 @@ jobs:
           echo GITHUB_REF_CLEANED=${GITHUB_REF_CLEANED}
           GITHUB_REF_CLEANED=${GITHUB_REF_CLEANED//\//-}
           echo GITHUB_REF_CLEANED=${GITHUB_REF_CLEANED}
-          BRANCH="${GITHUB_HEAD_REF:GITHUB_REF_CLEANED}"
+          BRANCH="${GITHUB_HEAD_REF:-GITHUB_REF_CLEANED}"
           echo "BRANCH=${BRANCH}"
           echo "BRANCH=${BRANCH}" >> $GITHUB_ENV
       - name: Append name of site to _config.yml
@@ -50,11 +50,11 @@ jobs:
         run: | 
           BRANCH_DIR=_branches.tmp
           mkdir -p $BRANCH_DIR
-          FILENAME=${BRANCH_DIR}/${{github.head_ref }}.md
+          FILENAME=${BRANCH_DIR}/${{ env.BRANCH }}.md
           rm -f $FILENAME
           touch $FILENAME
           echo "---" >> $FILENAME
-          echo "name: ${{ github.head_ref }}" >> $FILENAME
+          echo "name: ${{  env.BRANCH  }}" >> $FILENAME
           echo "actor: ${{ github.actor}}" >> $FILENAME
           echo "pull_request_url: ${{ github.event.pull_request.html_url}}" >> $FILENAME
           echo "pull_request_num: ${{ github.event.pull_request.number}}" >> $FILENAME
@@ -64,10 +64,10 @@ jobs:
         env:
           API_TOKEN_GITHUB: ${{ secrets.DOCS_TOKEN }}
         with:
-          source_file: 'frontend/_branches.tmp/${{github.head_ref }}.md'
+          source_file: 'frontend/_branches.tmp/${{  env.BRANCH  }}.md'
           destination_repo: ${{ github.repository }}-docs-qa
           destination_folder: 'docs/_branches'
-          commit_message: 'Add branch ${{ github.head_ref }} to docs-qa repo'
+          commit_message: 'Add branch ${{  env.BRANCH  }} to docs-qa repo'
           user_email: phtcon@ucsb.edu
           user_name: "Phill Conrad, UCSB CS machine user"
       - name: Install and Build 🔧
@@ -84,5 +84,5 @@ jobs:
           branch: main # The branch the action should deploy to.
           folder: frontend/storybook-static # The folder that the build-storybook script generates files.
           clean: true # Automatically remove deleted files from the deploy branch
-          target-folder: docs/storybook-qa/${{ github.head_ref}} # The folder that we serve our Storybook files from 
+          target-folder: docs/storybook-qa/${{  env.BRANCH }} # The folder that we serve our Storybook files from 
       

--- a/.github/workflows/publish-01-docs-to-github-pages-qa.yml
+++ b/.github/workflows/publish-01-docs-to-github-pages-qa.yml
@@ -17,11 +17,19 @@ jobs:
           persist-credentials: false
       - name: Figure out Branch name
         run: | 
+          GITHUB_HEAD_REF="${GITHUB_HEAD_REF}"
           echo GITHUB_HEAD_REF=${GITHUB_HEAD_REF}
-          echo GITHUB_REF=${GITHUB_REF}
+          GITHUB_REF_CLEANED=${GITHUB_REF/refs\/heads\//}
+          echo GITHUB_REF_CLEANED=${GITHUB_REF_CLEANED}
+          GITHUB_REF_CLEANED=${GITHUB_REF_CLEANED//\//-}
+          echo GITHUB_REF_CLEANED=${GITHUB_REF_CLEANED}
+          BRANCH="${GITHUB_HEAD_REF:GITHUB_REF_CLEANED}"
+          echo "BRANCH=${BRANCH}"
+          echo "BRANCH=${BRANCH}" >> $GITHUB_ENV
       - name: Append name of site to _config.yml
         working-directory: ./frontend/docs-qa-index
         run: | 
+          echo "env.BRANCH=${{ env.BRANCH }}"
           OWNER_PLUS_REPOSITORY=${{github.repository}}
           OWNER=${{ github.repository_owner }}
           REPOSITORY=${OWNER_PLUS_REPOSITORY/$OWNER\//}


### PR DESCRIPTION
# Overview

In this PR, we try to fix the `workflow_dispatch` logic for the -docs-qa repo.

We want to take the branch name from the PR when there is one; otherwise it should be the branch that was
specified when triggering the workflow, e.g.`main` here:

<img width="206" alt="image" src="https://user-images.githubusercontent.com/1119017/152704773-bf97ada9-b0db-402c-a913-da88fd0eec2e.png">

`pc-default-timeout` here:

<img width="270" alt="image" src="https://user-images.githubusercontent.com/1119017/152704788-79d4f9cd-0410-4004-a920-ce05caef0144.png">

etc.