### PR TITLE
pc - add test coverage and add endpoint to swagger

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/config/SpringFoxConfig.java
+++ b/src/main/java/edu/ucsb/cs156/example/config/SpringFoxConfig.java
@@ -30,7 +30,7 @@ public class SpringFoxConfig {
                 .apiInfo(apiInfo())
                 .select()
                 .apis(RequestHandlerSelectors.any())
-                .paths(regex("/api/.*"))
+                .paths(regex("/api/.*|/csrf"))
                 .build();
 
     }

--- a/src/main/java/edu/ucsb/cs156/example/controllers/CSRFController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/CSRFController.java
@@ -5,9 +5,14 @@ import org.springframework.security.web.csrf.CsrfToken;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+
 @Profile("development")
+@Api(description = "CSRF")
 @RestController
 public class CSRFController {
+  @ApiOperation(value = "Get a CSRF Token")
   @GetMapping("/csrf")
   public CsrfToken csrf(CsrfToken token) {
     return token;

--- a/src/main/java/edu/ucsb/cs156/example/controllers/CSRFController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/CSRFController.java
@@ -9,7 +9,7 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 
 @Profile("development")
-@Api(description = "CSRF")
+@Api(description = "CSRF (emabled only in development)")
 @RestController
 public class CSRFController {
   @ApiOperation(value = "Get a CSRF Token")

--- a/src/main/java/edu/ucsb/cs156/example/controllers/CSRFController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/CSRFController.java
@@ -9,7 +9,7 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 
 @Profile("development")
-@Api(description = "CSRF (emabled only in development)")
+@Api(description = "CSRF (enabled only in development; can be used with Postman to test APIs)")
 @RestController
 public class CSRFController {
   @ApiOperation(value = "Get a CSRF Token")

--- a/src/test/java/edu/ucsb/cs156/example/controllers/CSRFControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/CSRFControllerTests.java
@@ -1,0 +1,30 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@ActiveProfiles("development")
+@WebMvcTest(controllers = CSRFController.class)
+@Import(TestConfig.class)
+public class CSRFControllerTests extends ControllerTestCase {
+
+  @MockBean
+  UserRepository userRepository;
+
+  @Test
+  public void csrf_returns_ok() throws Exception {
+      mockMvc.perform(get("/csrf"))
+              .andExpect(status().isOk());
+  }
+
+}


### PR DESCRIPTION
# Overview

In this PR, we build on @sethvanb 's work in #31 by adding test coverage, and annotations for Swagger.

We also change the swagger configuration to include `/csrf` as a special case since it isn't prefixed with `/api`.

