### PR TITLE
pc - fix typo in docs-qa script

### DIFF
--- a/.github/workflows/00-publish-01-docs-to-github-pages-qa.yml
+++ b/.github/workflows/00-publish-01-docs-to-github-pages-qa.yml
@@ -23,7 +23,7 @@ jobs:
           echo GITHUB_REF_CLEANED=${GITHUB_REF_CLEANED}
           GITHUB_REF_CLEANED=${GITHUB_REF_CLEANED//\//-}
           echo GITHUB_REF_CLEANED=${GITHUB_REF_CLEANED}
-          BRANCH="${GITHUB_HEAD_REF:-GITHUB_REF_CLEANED}"
+          BRANCH="${GITHUB_HEAD_REF:-${GITHUB_REF_CLEANED}}"
           echo "BRANCH=${BRANCH}"
           echo "BRANCH=${BRANCH}" >> $GITHUB_ENV
       - name: Append name of site to _config.yml


### PR DESCRIPTION
fix typo in script that was assigning GITHUB_REF_CLEANED instead… of the value of GITHUB_REF_CLEANED to BRANCH

