### PR TITLE
pc - fix bug in PUT operation for Todos

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/TodosController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/TodosController.java
@@ -205,14 +205,16 @@ public class TodosController extends ApiController {
             return toe.error;
         }
 
-        // Even the admin can't change the user; they can change other details
-        // but not that.
+        Todo oldTodo = toe.todo;
+        oldTodo.setTitle(incomingTodo.getTitle());
+        oldTodo.setDetails(incomingTodo.getDetails());
+        oldTodo.setDone(incomingTodo.isDone());
+        // do not change the user; even the admin is not allowed to do that.
+        // note that for objects with no concept of "owner", this doesn't apply.
 
-        User previousUser = toe.todo.getUser();
-        incomingTodo.setUser(previousUser);
-        todoRepository.save(incomingTodo);
+        todoRepository.save(oldTodo);
 
-        String body = mapper.writeValueAsString(incomingTodo);
+        String body = mapper.writeValueAsString(oldTodo);
         return ResponseEntity.ok().body(body);
     }
 


### PR DESCRIPTION
# Overview

There was a bug in the sample code for the `PUT` method for the Todo class.

This PR brings that more into alignment with the example code from the Spring Guide to building REST APIs here: <https://spring.io/guides/tutorials/rest/>

In particular, the correct logic is to:
* Get the old objects from the database
* Set all of the fields (except the id, and any other fields that should not change) from the incoming object
* Store the *old* object back in the database.