### PR TITLE
Pc another simple database example

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDatesController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDatesController.java
@@ -91,7 +91,7 @@ public class UCSBDatesController extends ApiController {
     public ResponseEntity<String> postUCSBDate(
             @ApiParam("quarterYYYYQ") @RequestParam String quarterYYYYQ,
             @ApiParam("name") @RequestParam String name,
-            @ApiParam("date (in yyyy-mm-dd format)") @RequestParam("localDateTime") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime localDateTime)
+            @ApiParam("date (in iso format, e.g. YYYY-mm-ddTHH:MM:SS; see https://en.wikipedia.org/wiki/ISO_8601)") @RequestParam("localDateTime") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime localDateTime)
             throws JsonProcessingException {
 
         // For an explanation of @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) 

--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDatesController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDatesController.java
@@ -142,7 +142,7 @@ public class UCSBDatesController extends ApiController {
         UCSBDate oldDate = uoe.ucsbDate;
         oldDate.setQuarterYYYYQ(incoming.getQuarterYYYYQ());
         oldDate.setName(incoming.getName());
-        oldDate.setDate(incoming.getDate());
+        oldDate.setLocalDateTime(incoming.getLocalDateTime());
 
         ucsbDateRepository.save(oldDate);
 

--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDatesController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDatesController.java
@@ -25,13 +25,9 @@ import org.springframework.web.bind.annotation.RestController;
 
 import javax.validation.Valid;
 
-import java.text.DateFormat;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
+
 import java.time.LocalDateTime;
-import java.util.Date;
 import java.util.Optional;
-import java.util.TimeZone;
 
 @Api(description = "UCSBDates")
 @RequestMapping("/api/ucsbdates")
@@ -45,7 +41,7 @@ public class UCSBDatesController extends ApiController {
      * along with the error messages pertaining to those situations. It
      * bundles together the state needed for those checks.
      */
-    public class UCSBDateOrError {
+    private static class UCSBDateOrError {
         Long id;
         UCSBDate ucsbDate;
         ResponseEntity<String> error;

--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDatesController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDatesController.java
@@ -1,0 +1,179 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.entities.UCSBDate;
+import edu.ucsb.cs156.example.repositories.UCSBDateRepository;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import lombok.extern.slf4j.Slf4j;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
+import java.util.Date;
+import java.util.Optional;
+import java.util.TimeZone;
+
+@Api(description = "UCSBDates")
+@RequestMapping("/api/ucsbdates")
+@RestController
+@Slf4j
+public class UCSBDatesController extends ApiController {
+
+    /**
+     * This inner class helps us factor out some code for checking
+     * whether UCSBDate's exist,
+     * along with the error messages pertaining to those situations. It
+     * bundles together the state needed for those checks.
+     */
+    public class UCSBDateOrError {
+        Long id;
+        UCSBDate ucsbDate;
+        ResponseEntity<String> error;
+
+        public UCSBDateOrError(Long id) {
+            this.id = id;
+        }
+    }
+
+    @Autowired
+    UCSBDateRepository ucsbDateRepository;
+
+    @Autowired
+    ObjectMapper mapper;
+
+    @ApiOperation(value = "List all ucsb dates")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/all")
+    public Iterable<UCSBDate> allUCSBDates() {
+        Iterable<UCSBDate> dates = ucsbDateRepository.findAll();
+        return dates;
+    }
+
+    @ApiOperation(value = "Get a single date")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("")
+    public ResponseEntity<String> getById(
+            @ApiParam("id") @RequestParam Long id) throws JsonProcessingException {
+        UCSBDateOrError uoe = new UCSBDateOrError(id);
+
+        uoe = doesUCSBDateExist(uoe);
+        if (uoe.error != null) {
+            return uoe.error;
+        }
+
+        String body = mapper.writeValueAsString(uoe.ucsbDate);
+        return ResponseEntity.ok().body(body);
+    }
+
+    @ApiOperation(value = "Create a new date")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/post")
+    public ResponseEntity<String> postUCSBDate(
+            @ApiParam("quarterYYYYQ") @RequestParam String quarterYYYYQ,
+            @ApiParam("name") @RequestParam String name,
+            @ApiParam("date (in yyyy-mm-dd format)") @RequestParam("localDateTime") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime localDateTime)
+            throws JsonProcessingException {
+
+        // For an explanation of @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) 
+        // See: https://www.baeldung.com/spring-date-parameters
+
+        log.info("localDateTime={}", localDateTime);
+
+        UCSBDate ucsbDate = new UCSBDate();
+        ucsbDate.setQuarterYYYYQ(quarterYYYYQ);
+        ucsbDate.setName(name);
+        ucsbDate.setLocalDateTime(localDateTime);
+
+        UCSBDate savedUcsbDate = ucsbDateRepository.save(ucsbDate);
+        String json = mapper.writeValueAsString(savedUcsbDate);
+        return ResponseEntity.ok().body(json);
+    }
+
+
+    @ApiOperation(value = "Delete a UCSBDate")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @DeleteMapping("")
+    public ResponseEntity<String> deleteUCSBDate(
+            @ApiParam("id") @RequestParam Long id) {
+        UCSBDateOrError uoe = new UCSBDateOrError(id);
+
+        uoe = doesUCSBDateExist(uoe);
+        if (uoe.error != null) {
+            return uoe.error;
+        }
+
+        ucsbDateRepository.deleteById(id);
+        return ResponseEntity.ok().body(String.format("UCSBDate with id %d deleted", id));
+    }
+
+    @ApiOperation(value = "Update a single date")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PutMapping("")
+    public ResponseEntity<String> updateUCSBDate(
+            @ApiParam("id") @RequestParam Long id,
+            @RequestBody @Valid UCSBDate incoming) throws JsonProcessingException {
+        UCSBDateOrError uoe = new UCSBDateOrError(id);
+
+        uoe = doesUCSBDateExist(uoe);
+        if (uoe.error != null) {
+            return uoe.error;
+        }
+
+        UCSBDate oldDate = uoe.ucsbDate;
+        oldDate.setQuarterYYYYQ(incoming.getQuarterYYYYQ());
+        oldDate.setName(incoming.getName());
+        oldDate.setDate(incoming.getDate());
+
+        ucsbDateRepository.save(oldDate);
+
+        String body = mapper.writeValueAsString(oldDate);
+        return ResponseEntity.ok().body(body);
+    }
+
+    /**
+     * Pre-conditions: uoe.id is value to look up, uoe.ucsbDate and uoe.error are
+     * null
+     *
+     * Post-condition: if UCSBDate with id uoe.id exists, uoe.ucsbDate now refers to
+     * it, and
+     * error is null.
+     * Otherwise, UCSBDate with id uoe.id does not exist, and error is a suitable
+     * return
+     * value to
+     * report this error condition.
+     */
+    public UCSBDateOrError doesUCSBDateExist(UCSBDateOrError uoe) {
+
+        Optional<UCSBDate> optionalUCSBDate = ucsbDateRepository.findById(uoe.id);
+
+        if (optionalUCSBDate.isEmpty()) {
+            uoe.error = ResponseEntity
+                    .badRequest()
+                    .body(String.format("UCSBDate with id %d not found", uoe.id));
+        } else {
+            uoe.ucsbDate = optionalUCSBDate.get();
+        }
+        return uoe;
+    }
+
+}

--- a/src/main/java/edu/ucsb/cs156/example/entities/UCSBDate.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/UCSBDate.java
@@ -2,14 +2,16 @@ package edu.ucsb.cs156.example.entities;
 
 
 import java.time.LocalDateTime;
+import java.util.Date;
 
 import javax.persistence.Entity;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
 import javax.persistence.GeneratedValue;
 
 
-import org.springframework.format.annotation.DateTimeFormat;
 
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -28,5 +30,9 @@ public class UCSBDate {
 
   private String quarterYYYYQ;
   private String name;
-  private  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime localDateTime;
+
+  // @Temporal(TemporalType.DATE)
+  // Date date;
+  
+  LocalDateTime localDateTime;
 }

--- a/src/main/java/edu/ucsb/cs156/example/entities/UCSBDate.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/UCSBDate.java
@@ -1,17 +1,11 @@
 package edu.ucsb.cs156.example.entities;
 
-
 import java.time.LocalDateTime;
-import java.util.Date;
 
 import javax.persistence.Entity;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import javax.persistence.Temporal;
-import javax.persistence.TemporalType;
 import javax.persistence.GeneratedValue;
-
-
 
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -29,10 +23,6 @@ public class UCSBDate {
   private long id;
 
   private String quarterYYYYQ;
-  private String name;
-
-  // @Temporal(TemporalType.DATE)
-  // Date date;
-  
-  LocalDateTime localDateTime;
+  private String name;  
+  private LocalDateTime localDateTime;
 }

--- a/src/main/java/edu/ucsb/cs156/example/entities/UCSBDate.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/UCSBDate.java
@@ -1,11 +1,15 @@
 package edu.ucsb.cs156.example.entities;
 
+
+import java.time.LocalDateTime;
+
 import javax.persistence.Entity;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.GeneratedValue;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
+
+
+import org.springframework.format.annotation.DateTimeFormat;
 
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -16,20 +20,13 @@ import lombok.Builder;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
-@Entity(name = "todos")
-public class Todo {
+@Entity(name = "ucsbdates")
+public class UCSBDate {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private long id;
 
-  // This establishes that many todos can belong to one user
-  // Only the user_id is stored in the table, and through it we
-  // can access the user's details
-
-  @ManyToOne
-  @JoinColumn(name = "user_id")
-  private User user;
-  private String title;
-  private String details;
-  private boolean done;
+  private String quarterYYYYQ;
+  private String name;
+  private  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime localDateTime;
 }

--- a/src/main/java/edu/ucsb/cs156/example/entities/User.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/User.java
@@ -1,11 +1,14 @@
 package edu.ucsb.cs156.example.entities;
 
-import com.fasterxml.jackson.annotation.JsonView;
-import lombok.*;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.AuthorityUtils;
-
-import javax.persistence.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.AccessLevel;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 
 @Data
 @AllArgsConstructor

--- a/src/main/java/edu/ucsb/cs156/example/repositories/TodoRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/TodoRepository.java
@@ -4,7 +4,6 @@ import edu.ucsb.cs156.example.entities.Todo;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.Optional;
 
 @Repository
 public interface TodoRepository extends CrudRepository<Todo, Long> {

--- a/src/main/java/edu/ucsb/cs156/example/repositories/UCSBDateRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/UCSBDateRepository.java
@@ -1,0 +1,12 @@
+package edu.ucsb.cs156.example.repositories;
+
+import edu.ucsb.cs156.example.entities.UCSBDate;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+
+@Repository
+public interface UCSBDateRepository extends CrudRepository<UCSBDate, Long> {
+  Iterable<UCSBDate> findAllByquarterYYYYQ(String quarterYYYYQ);
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/UCSBDateRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/UCSBDateRepository.java
@@ -8,5 +8,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface UCSBDateRepository extends CrudRepository<UCSBDate, Long> {
-  Iterable<UCSBDate> findAllByquarterYYYYQ(String quarterYYYYQ);
+  Iterable<UCSBDate> findAllByQuarterYYYYQ(String quarterYYYYQ);
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -24,3 +24,4 @@ server.compression.enabled=false
 
 spring.data.mongodb.uri=${MONGODB_URI:${env.MONGODB_URI:mongodb+srv://fakeUsername:fakePassword@cluster0.ulqcw.mongodb.net/fakeDatabase?retryWrites=true&w=majority}}
 
+spring.mvc.format.date-time=iso

--- a/src/test/java/edu/ucsb/cs156/example/controllers/SystemInfoControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/SystemInfoControllerTests.java
@@ -38,7 +38,7 @@ public class SystemInfoControllerTests extends ControllerTestCase {
         .andExpect(status().is(403));
   }
 
-  @WithMockUser(roles = { "ADMIN" })
+  @WithMockUser(roles = { "ADMIN", "USER" })
   @Test
   public void systemInfo__admin_logged_in() throws Exception {
 

--- a/src/test/java/edu/ucsb/cs156/example/controllers/TodosControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/TodosControllerTests.java
@@ -61,7 +61,7 @@ public class TodosControllerTests extends ControllerTestCase {
                 .andExpect(status().is(403));
     }
 
-    @WithMockUser(roles = { "ADMIN" })
+    @WithMockUser(roles = { "ADMIN", "USER" })
     @Test
     public void api_todos_admin_all__admin_logged_in__returns_200() throws Exception {
         mockMvc.perform(get("/api/todos/admin/all"))
@@ -160,7 +160,7 @@ public class TodosControllerTests extends ControllerTestCase {
         assertEquals("todo with id 13 not found", responseString);
     }
 
-    @WithMockUser(roles = { "ADMIN" })
+    @WithMockUser(roles = { "ADMIN", "USER" })
     @Test
     public void api_todos__admin_logged_in__search_for_todo_that_belongs_to_another_user() throws Exception {
 
@@ -185,7 +185,7 @@ public class TodosControllerTests extends ControllerTestCase {
         assertEquals(expectedJson, responseString);
     }
 
-    @WithMockUser(roles = { "ADMIN" })
+    @WithMockUser(roles = { "ADMIN", "USER" })
     @Test
     public void api_todos__admin_logged_in__search_for_todo_that_does_not_exist() throws Exception {
 
@@ -204,7 +204,7 @@ public class TodosControllerTests extends ControllerTestCase {
         assertEquals("todo with id 29 not found", responseString);
     }
 
-    @WithMockUser(roles = { "ADMIN" })
+    @WithMockUser(roles = { "ADMIN", "USER" })
     @Test
     public void api_todos_admin_all__admin_logged_in__returns_all_todos() throws Exception {
 
@@ -357,7 +357,7 @@ public class TodosControllerTests extends ControllerTestCase {
     }
 
 
-    @WithMockUser(roles = { "ADMIN" })
+    @WithMockUser(roles = { "ADMIN", "USER" })
     @Test
     public void api_todos__admin_logged_in__delete_todo() throws Exception {
         // arrange
@@ -379,7 +379,7 @@ public class TodosControllerTests extends ControllerTestCase {
         assertEquals("todo with id 16 deleted", responseString);
     }
 
-    @WithMockUser(roles = { "ADMIN" })
+    @WithMockUser(roles = { "ADMIN", "USER" })
     @Test
     public void api_todos__admin_logged_in__cannot_delete_todo_that_does_not_exist() throws Exception {
         // arrange
@@ -491,7 +491,7 @@ public class TodosControllerTests extends ControllerTestCase {
     }
 
 
-    @WithMockUser(roles = { "ADMIN" })
+    @WithMockUser(roles = { "ADMIN", "USER" })
     @Test
     public void api_todos__admin_logged_in__put_todo() throws Exception {
         // arrange
@@ -527,7 +527,7 @@ public class TodosControllerTests extends ControllerTestCase {
         assertEquals(expectedJson, responseString);
     }
 
-    @WithMockUser(roles = { "ADMIN" })
+    @WithMockUser(roles = { "ADMIN", "USER" })
     @Test
     public void api_todos__admin_logged_in__cannot_put_todo_that_does_not_exist() throws Exception {
         // arrange

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDatesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDatesControllerTests.java
@@ -1,0 +1,313 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.UCSBDate;
+import edu.ucsb.cs156.example.repositories.UCSBDateRepository;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Optional;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@WebMvcTest(controllers = UCSBDatesController.class)
+@Import(TestConfig.class)
+public class UCSBDatesControllerTests extends ControllerTestCase {
+
+        @MockBean
+        UCSBDateRepository ucsbDateRepository;
+
+        @MockBean
+        UserRepository userRepository;
+
+        // Authorization tests for /api/ucsbdates/admin/all
+
+        @Test
+        public void logged_out_users_cannot_get_all() throws Exception {
+                mockMvc.perform(get("/api/ucsbdates/all"))
+                                .andExpect(status().is(403)); // logged out users can't get all
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_users_can_get_all() throws Exception {
+                mockMvc.perform(get("/api/ucsbdates/all"))
+                                .andExpect(status().is(200)); // logged
+        }
+
+        @Test
+        public void logged_out_users_cannot_get_by_id() throws Exception {
+                mockMvc.perform(get("/api/ucsbdates?id=7"))
+                                .andExpect(status().is(403)); // logged out users can't get by id
+        }
+
+        // Authorization tests for /api/ucsbdates/post
+        // (Perhaps should also have these for put and delete)
+
+        @Test
+        public void logged_out_users_cannot_post() throws Exception {
+                mockMvc.perform(post("/api/ucsbdates/post"))
+                                .andExpect(status().is(403));
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_regular_users_cannot_post() throws Exception {
+                mockMvc.perform(post("/api/ucsbdates/post"))
+                                .andExpect(status().is(403)); // only admins can post
+        }
+
+        // Tests with mocks for database actions
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void test_that_logged_in_user_can_get_by_id_when_the_id_exists() throws Exception {
+
+                // arrange
+                LocalDateTime ldt = LocalDateTime.parse("2022-01-03T00:00:00");
+
+                UCSBDate ucsbDate = UCSBDate.builder()
+                                .name("firstDayOfClasses")
+                                .quarterYYYYQ("20222")
+                                .localDateTime(ldt)
+                                .build();
+
+                when(ucsbDateRepository.findById(eq(7L))).thenReturn(Optional.of(ucsbDate));
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/ucsbdates?id=7"))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+
+                verify(ucsbDateRepository, times(1)).findById(eq(7L));
+                String expectedJson = mapper.writeValueAsString(ucsbDate);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void test_that_logged_in_user_can_get_by_id_when_the_id_does_not_exist() throws Exception {
+
+                // arrange
+
+                when(ucsbDateRepository.findById(eq(7L))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/ucsbdates?id=7"))
+                                .andExpect(status().isBadRequest()).andReturn();
+
+                // assert
+
+                verify(ucsbDateRepository, times(1)).findById(eq(7L));
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals("UCSBDate with id 7 not found", responseString);
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_user_can_get_all_ucsbdates() throws Exception {
+
+                // arrange
+                LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+                UCSBDate ucsbDate1 = UCSBDate.builder()
+                                .name("firstDayOfClasses")
+                                .quarterYYYYQ("20222")
+                                .localDateTime(ldt1)
+                                .build();
+
+                LocalDateTime ldt2 = LocalDateTime.parse("2022-03-11T00:00:00");
+
+                UCSBDate ucsbDate2 = UCSBDate.builder()
+                                .name("lastDayOfClasses")
+                                .quarterYYYYQ("20222")
+                                .localDateTime(ldt2)
+                                .build();
+
+                ArrayList<UCSBDate> expectedDates = new ArrayList<>();
+                expectedDates.addAll(Arrays.asList(ucsbDate1, ucsbDate2));
+
+                when(ucsbDateRepository.findAll()).thenReturn(expectedDates);
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/ucsbdates/all"))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+
+                verify(ucsbDateRepository, times(1)).findAll();
+                String expectedJson = mapper.writeValueAsString(expectedDates);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+        @WithMockUser(roles = { "ADMIN" })
+        @Test
+        public void an_admin_user_can_post_a_new_ucsbdate() throws Exception {
+                // arrange
+
+                LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+                UCSBDate ucsbDate1 = UCSBDate.builder()
+                                .name("firstDayOfClasses")
+                                .quarterYYYYQ("20222")
+                                .localDateTime(ldt1)
+                                .build();
+
+                when(ucsbDateRepository.save(eq(ucsbDate1))).thenReturn(ucsbDate1);
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                post("/api/ucsbdates/post?name=firstDayOfClasses&quarterYYYYQ=20222&localDateTime=2022-01-03T00:00:00")
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(ucsbDateRepository, times(1)).save(ucsbDate1);
+                String expectedJson = mapper.writeValueAsString(ucsbDate1);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+        @WithMockUser(roles = { "ADMIN" })
+        @Test
+        public void admin_can_delete_a_date() throws Exception {
+                // arrange
+
+                LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+                UCSBDate ucsbDate1 = UCSBDate.builder()
+                                .name("firstDayOfClasses")
+                                .quarterYYYYQ("20222")
+                                .localDateTime(ldt1)
+                                .build();
+             
+               
+                when(ucsbDateRepository.findById(eq(15L))).thenReturn(Optional.of(ucsbDate1));
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                delete("/api/ucsbdates?id=15")
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(ucsbDateRepository, times(1)).findById(15L);
+                verify(ucsbDateRepository, times(1)).deleteById(15L);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals("UCSBDate with id 15 deleted", responseString);
+        }
+
+        @WithMockUser(roles = { "ADMIN" })
+        @Test
+        public void admin_tries_to_delete_non_existant_ucsbdate_and_gets_right_error_message() throws Exception {
+                // arrange
+
+                when(ucsbDateRepository.findById(eq(15L))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                delete("/api/ucsbdates?id=15")
+                                                .with(csrf()))
+                                .andExpect(status().isBadRequest()).andReturn();
+
+                // assert
+                verify(ucsbDateRepository, times(1)).findById(15L);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals("UCSBDate with id 15 not found", responseString);
+        }
+
+    
+        @WithMockUser(roles = { "ADMIN" })
+        @Test
+        public void admin_can_edit_an_existing_ucsbdate() throws Exception {
+                // arrange
+
+                LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+                LocalDateTime ldt2 = LocalDateTime.parse("2023-01-03T00:00:00");
+
+                UCSBDate ucsbDateOrig = UCSBDate.builder()
+                                .name("firstDayOfClasses")
+                                .quarterYYYYQ("20222")
+                                .localDateTime(ldt1)
+                                .build();
+             
+                UCSBDate ucsbDateEdited = UCSBDate.builder()
+                                .name("firstDayOfFestivus")
+                                .quarterYYYYQ("20232")
+                                .localDateTime(ldt2)
+                                .build();
+             
+                String requestBody = mapper.writeValueAsString(ucsbDateEdited);
+
+                when(ucsbDateRepository.findById(eq(67L))).thenReturn(Optional.of(ucsbDateOrig));
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                put("/api/ucsbdates?id=67")
+                                                .contentType(MediaType.APPLICATION_JSON)
+                                                .characterEncoding("utf-8")
+                                                .content(requestBody)
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(ucsbDateRepository, times(1)).findById(67L);
+                verify(ucsbDateRepository, times(1)).save(ucsbDateEdited); // should be saved with correct user
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(requestBody, responseString);
+        }
+
+        @WithMockUser(roles = { "ADMIN" })
+        @Test
+        public void admin_cannot_edit_ucsbdate_that_does_not_exist() throws Exception {
+                // arrange
+
+                LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+                UCSBDate ucsbEditedDate = UCSBDate.builder()
+                                .name("firstDayOfClasses")
+                                .quarterYYYYQ("20222")
+                                .localDateTime(ldt1)
+                                .build();
+
+                String requestBody = mapper.writeValueAsString(ucsbEditedDate);
+
+                when(ucsbDateRepository.findById(eq(67L))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                put("/api/ucsbdates?id=67")
+                                                .contentType(MediaType.APPLICATION_JSON)
+                                                .characterEncoding("utf-8")
+                                                .content(requestBody)
+                                                .with(csrf()))
+                                .andExpect(status().isBadRequest()).andReturn();
+
+                // assert
+                verify(ucsbDateRepository, times(1)).findById(67L);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals("UCSBDate with id 67 not found", responseString);
+        }
+}

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDatesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDatesControllerTests.java
@@ -162,7 +162,7 @@ public class UCSBDatesControllerTests extends ControllerTestCase {
                 assertEquals(expectedJson, responseString);
         }
 
-        @WithMockUser(roles = { "ADMIN" })
+        @WithMockUser(roles = { "ADMIN", "USER" })
         @Test
         public void an_admin_user_can_post_a_new_ucsbdate() throws Exception {
                 // arrange
@@ -190,7 +190,7 @@ public class UCSBDatesControllerTests extends ControllerTestCase {
                 assertEquals(expectedJson, responseString);
         }
 
-        @WithMockUser(roles = { "ADMIN" })
+        @WithMockUser(roles = { "ADMIN", "USER" })
         @Test
         public void admin_can_delete_a_date() throws Exception {
                 // arrange
@@ -219,7 +219,7 @@ public class UCSBDatesControllerTests extends ControllerTestCase {
                 assertEquals("UCSBDate with id 15 deleted", responseString);
         }
 
-        @WithMockUser(roles = { "ADMIN" })
+        @WithMockUser(roles = { "ADMIN", "USER" })
         @Test
         public void admin_tries_to_delete_non_existant_ucsbdate_and_gets_right_error_message() throws Exception {
                 // arrange
@@ -239,7 +239,7 @@ public class UCSBDatesControllerTests extends ControllerTestCase {
         }
 
     
-        @WithMockUser(roles = { "ADMIN" })
+        @WithMockUser(roles = { "ADMIN", "USER" })
         @Test
         public void admin_can_edit_an_existing_ucsbdate() throws Exception {
                 // arrange
@@ -279,7 +279,7 @@ public class UCSBDatesControllerTests extends ControllerTestCase {
                 assertEquals(requestBody, responseString);
         }
 
-        @WithMockUser(roles = { "ADMIN" })
+        @WithMockUser(roles = { "ADMIN", "USER" })
         @Test
         public void admin_cannot_edit_ucsbdate_that_does_not_exist() throws Exception {
                 // arrange

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UsersControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UsersControllerTests.java
@@ -42,7 +42,7 @@ public class UsersControllerTests extends ControllerTestCase {
         .andExpect(status().is(403));
   }
 
-  @WithMockUser(roles = { "ADMIN" })
+  @WithMockUser(roles = { "ADMIN", "USER" })
   @Test
   public void users__admin_logged_in() throws Exception {
 


### PR DESCRIPTION
NOTE: This one will be simpler after #35 is merged; right now it also includes all of the changes in #35.

I will also need to update it based on the changes from the code review made to #35.

# Overview

In this PR, we add another simple CRUD example for UCSBDates

* an `@Entity`
* a `@Repository`
* a Controller
* Controller test cases

The purpose is to provide a simpler example than the `todos` where there isn't a foreign key, and the permissions are simple: logged in users are read only, admins are read/write, and non-logged in users have no permissions.