### PR TITLE
pc Add Placeholder pages and Navigation for UCSBDates CRUD operations

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -32,6 +32,23 @@ function App() {
             </>
           )
         }
+
+        {
+          hasRole(currentUser, "ROLE_USER") && (
+            <>
+              <Route path="/ucsbdates/list" element={<TodosIndexPage />} />
+            </>
+          )
+        }
+        {
+          hasRole(currentUser, "ROLE_ADMIN") && (
+            <>
+              <Route path="/ucsbdates/edit/:id" element={<TodosEditPage />} />
+              <Route path="/ucsbdates/create" element={<TodosCreatePage />} />
+            </>
+          )
+        }
+
       </Routes>
     </BrowserRouter>
   );

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -2,9 +2,14 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 import HomePage from "main/pages/HomePage";
 import ProfilePage from "main/pages/ProfilePage";
 import AdminUsersPage from "main/pages/AdminUsersPage";
+
 import TodosIndexPage from "main/pages/Todos/TodosIndexPage";
 import TodosCreatePage from "main/pages/Todos/TodosCreatePage";
 import TodosEditPage from "main/pages/Todos/TodosEditPage";
+
+import UCSBDatesIndexPage from "main/pages/UCSBDates/UCSBDatesIndexPage";
+import UCSBDatesCreatePage from "main/pages/UCSBDates/UCSBDatesCreatePage";
+import UCSBDatesEditPage from "main/pages/UCSBDates/UCSBDatesEditPage";
 
 import { hasRole, useCurrentUser } from "main/utils/currentUser";
 
@@ -36,15 +41,15 @@ function App() {
         {
           hasRole(currentUser, "ROLE_USER") && (
             <>
-              <Route path="/ucsbdates/list" element={<TodosIndexPage />} />
+              <Route path="/ucsbdates/list" element={<UCSBDatesIndexPage />} />
             </>
           )
         }
         {
           hasRole(currentUser, "ROLE_ADMIN") && (
             <>
-              <Route path="/ucsbdates/edit/:id" element={<TodosEditPage />} />
-              <Route path="/ucsbdates/create" element={<TodosCreatePage />} />
+              <Route path="/ucsbdates/edit/:id" element={<UCSBDatesEditPage />} />
+              <Route path="/ucsbdates/create" element={<UCSBDatesCreatePage />} />
             </>
           )
         }

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -20,6 +20,27 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
 
           <Navbar.Toggle />
 
+          <Nav className="me-auto">
+            {
+              systemInfo?.springH2ConsoleEnabled && (
+                <>
+                  <Nav.Link href="/h2-console">H2Console</Nav.Link>
+                </>
+              )
+            }
+            {
+              systemInfo?.showSwaggerUILink && (
+                <>
+                  <Nav.Link href="/swagger-ui/index.html">Swagger</Nav.Link>
+                </>
+              )
+            }
+          </Nav>
+
+          <>
+            {/* be sure that each NavDropdown has a unique id and data-testid  */}
+          </>
+
           <Navbar.Collapse className="justify-content-between">
             <Nav className="mr-auto">
               {
@@ -30,10 +51,6 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
                 )
               }
             </Nav>
-
-            <>
-              {/* be sure that each NavDropdown has a unique id and data-testid  */}
-            </>
 
             <Nav className="mr-auto">
               {
@@ -46,19 +63,17 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
               }
             </Nav>
 
-            <Nav className="me-auto">
+            <Nav className="mr-auto">
               {
-                systemInfo?.springH2ConsoleEnabled && (
-                  <>
-                    <Nav.Link href="/h2-console">H2Console</Nav.Link>
-                  </>
-                )
-              }
-              {
-                systemInfo?.showSwaggerUILink && (
-                  <>
-                    <Nav.Link href="/swagger-ui/index.html">Swagger</Nav.Link>
-                  </>
+                hasRole(currentUser, "ROLE_USER") && (
+                  <NavDropdown title="UCSBDates" id="appnavbar-ucsbdates-dropdown" data-testid="appnavbar-ucsbdates-dropdown" >
+                    <NavDropdown.Item href="/ucsbdates/list" data-testid="appnavbar-ucsbdates-list">List</NavDropdown.Item>
+                    {
+                      hasRole(currentUser, "ROLE_ADMIN") && (
+                        <NavDropdown.Item href="/ucsbdates/create" data-testid="appnavbar-ucsbdates-create">Create</NavDropdown.Item>
+                      )
+                    }
+                  </NavDropdown>
                 )
               }
             </Nav>

--- a/frontend/src/main/pages/UCSBDates/UCSBDatesCreatePage.js
+++ b/frontend/src/main/pages/UCSBDates/UCSBDatesCreatePage.js
@@ -1,0 +1,14 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function UCSBDatesCreatePage() {
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>UCSBDates</h1>
+        <p>
+          This is where the create page will go
+        </p>
+      </div>
+    </BasicLayout>
+  )
+}

--- a/frontend/src/main/pages/UCSBDates/UCSBDatesEditPage.js
+++ b/frontend/src/main/pages/UCSBDates/UCSBDatesEditPage.js
@@ -1,0 +1,14 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function UCSBDatesEditPage() {
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>UCSBDates</h1>
+        <p>
+          This is where the edit page will go
+        </p>
+      </div>
+    </BasicLayout>
+  )
+}

--- a/frontend/src/main/pages/UCSBDates/UCSBDatesIndexPage.js
+++ b/frontend/src/main/pages/UCSBDates/UCSBDatesIndexPage.js
@@ -1,0 +1,14 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function UCSBDatesIndexPage() {
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>UCSBDates</h1>
+        <p>
+          This is where the index page will go
+        </p>
+      </div>
+    </BasicLayout>
+  )
+}

--- a/frontend/src/stories/pages/UCSBDates/UCSBDatesCreatePage.stories.js
+++ b/frontend/src/stories/pages/UCSBDates/UCSBDatesCreatePage.stories.js
@@ -1,0 +1,17 @@
+
+import React from 'react';
+
+import UCSBDatesCreatePage from "main/pages/UCSBDates/UCSBDatesCreatePage";
+
+export default {
+    title: 'pages/UCSBDates/UCSBDatesCreatePage',
+    component: UCSBDatesCreatePage
+};
+
+const Template = () => <UCSBDatesCreatePage />;
+
+export const Default = Template.bind({});
+
+
+
+

--- a/frontend/src/stories/pages/UCSBDates/UCSBDatesEditPage.stories.js
+++ b/frontend/src/stories/pages/UCSBDates/UCSBDatesEditPage.stories.js
@@ -1,0 +1,16 @@
+
+import React from 'react';
+
+import UCSBDatesEditPage from "main/pages/UCSBDates/UCSBDatesEditPage";
+
+export default {
+    title: 'pages/UCSBDates/UCSBDatesEditPage',
+    component: UCSBDatesEditPage
+};
+
+const Template = () => <UCSBDatesEditPage />;
+
+export const Default = Template.bind({});
+
+
+

--- a/frontend/src/stories/pages/UCSBDates/UCSBDatesIndexPage.stories.js
+++ b/frontend/src/stories/pages/UCSBDates/UCSBDatesIndexPage.stories.js
@@ -1,0 +1,17 @@
+
+import React from 'react';
+
+import UCSBDatesIndexPage from "main/pages/UCSBDates/UCSBDatesIndexPage";
+
+export default {
+    title: 'pages/UCSBDates/UCSBDatesIndexPage',
+    component: UCSBDatesIndexPage
+};
+
+const Template = () => <UCSBDatesIndexPage />;
+
+export const Default = Template.bind({});
+
+
+
+

--- a/frontend/src/tests/components/Nav/AppNavbar.test.js
+++ b/frontend/src/tests/components/Nav/AppNavbar.test.js
@@ -189,7 +189,7 @@ describe("AppNavbar tests", () => {
 
     });
 
-    test("renders the ucsbdates menu correctly for a user", async () => {
+    test("renders the ucsbdates menu correctly for an admin", async () => {
 
         const currentUser = currentUserFixtures.adminUser;
         const systemInfo = systemInfoFixtures.showingBoth;

--- a/frontend/src/tests/components/Nav/AppNavbar.test.js
+++ b/frontend/src/tests/components/Nav/AppNavbar.test.js
@@ -1,4 +1,4 @@
-import { render, waitFor } from "@testing-library/react";
+import { render, waitFor, fireEvent } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 import { currentUserFixtures } from "fixtures/currentUserFixtures";
@@ -164,6 +164,55 @@ describe("AppNavbar tests", () => {
         await waitFor(() => expect(getByTestId("AppNavbar")).toBeInTheDocument());
         expect(queryByTestId(/AppNavbarLocalhost/i)).toBeNull();
     });
+
+    test("renders the ucsbdates menu correctly for a user", async () => {
+
+        const currentUser = currentUserFixtures.userOnly;
+        const systemInfo = systemInfoFixtures.showingBoth;
+
+        const doLogin = jest.fn();
+
+        const {getByTestId  } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AppNavbar currentUser={currentUser} systemInfo={systemInfo} doLogin={doLogin} />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => expect(getByTestId("appnavbar-ucsbdates-dropdown")).toBeInTheDocument());
+        const dropdown = getByTestId("appnavbar-ucsbdates-dropdown");
+        const aElement = dropdown.querySelector("a");
+        expect(aElement).toBeInTheDocument();
+        aElement?.click();
+        await waitFor( () => expect(getByTestId(/appnavbar-ucsbdates-list/)).toBeInTheDocument() );
+
+    });
+
+    test("renders the ucsbdates menu correctly for a user", async () => {
+
+        const currentUser = currentUserFixtures.adminUser;
+        const systemInfo = systemInfoFixtures.showingBoth;
+
+        const doLogin = jest.fn();
+
+        const {getByTestId  } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AppNavbar currentUser={currentUser} systemInfo={systemInfo} doLogin={doLogin} />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => expect(getByTestId("appnavbar-ucsbdates-dropdown")).toBeInTheDocument());
+        const dropdown = getByTestId("appnavbar-ucsbdates-dropdown");
+        const aElement = dropdown.querySelector("a");
+        expect(aElement).toBeInTheDocument();
+        aElement?.click();
+        await waitFor( () => expect(getByTestId(/appnavbar-ucsbdates-create/)).toBeInTheDocument() );
+
+    });
+
 
 });
 

--- a/frontend/src/tests/components/Nav/AppNavbar.test.js
+++ b/frontend/src/tests/components/Nav/AppNavbar.test.js
@@ -1,4 +1,4 @@
-import { render, waitFor, fireEvent } from "@testing-library/react";
+import { render, waitFor} from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 import { currentUserFixtures } from "fixtures/currentUserFixtures";

--- a/frontend/src/tests/pages/UCSBDates/Todos/UCSBDatesCreatePage.test.js
+++ b/frontend/src/tests/pages/UCSBDates/Todos/UCSBDatesCreatePage.test.js
@@ -1,0 +1,31 @@
+import { render } from "@testing-library/react";
+import UCSBDatesCreatePage from "main/pages/UCSBDates/UCSBDatesCreatePage";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import { apiCurrentUserFixtures }  from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+
+describe("UCSBDatesCreatePage tests", () => {
+
+    var axiosMock = new AxiosMockAdapter(axios);
+    axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+
+    const queryClient = new QueryClient();
+    test("renders without crashing", () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <UCSBDatesCreatePage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+    });
+
+});
+
+

--- a/frontend/src/tests/pages/UCSBDates/Todos/UCSBDatesEditPage.test.js
+++ b/frontend/src/tests/pages/UCSBDates/Todos/UCSBDatesEditPage.test.js
@@ -1,0 +1,31 @@
+import { render } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import UCSBDatesEditPage from "main/pages/UCSBDates/UCSBDatesEditPage";
+
+import { apiCurrentUserFixtures }  from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+
+describe("UCSBDatesCreatePage tests", () => {
+
+    var axiosMock = new AxiosMockAdapter(axios);
+    axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+
+    const queryClient = new QueryClient();
+    test("renders without crashing", () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <UCSBDatesEditPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+    });
+
+});
+
+

--- a/frontend/src/tests/pages/UCSBDates/Todos/UCSBDatesIndexPage.test.js
+++ b/frontend/src/tests/pages/UCSBDates/Todos/UCSBDatesIndexPage.test.js
@@ -1,0 +1,31 @@
+import { render } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import UCSBDatesIndexPage from "main/pages/UCSBDates/UCSBDatesIndexPage";
+
+
+import { apiCurrentUserFixtures }  from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+describe("UCSBDatesIndexPage tests", () => {
+
+    var axiosMock = new AxiosMockAdapter(axios);
+    axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+
+    const queryClient = new QueryClient();
+    test("renders without crashing", () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <UCSBDatesIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+    });
+
+});
+
+


### PR DESCRIPTION
# Overview

In this PR, we add placeholder pages for CRUD operations for UCSBDates, and we add a menu on the navigation bar.

Here's what the menu looks like for a regular user—only the `List` option is showing:

![image](https://user-images.githubusercontent.com/1119017/153698110-928e025c-cf46-4c5c-95e5-df9c0835646f.png)

Here's what the menu looks like for an admin user: both the `List` and `Create` options are showing:

![image](https://user-images.githubusercontent.com/1119017/153698135-9f1032aa-a0e1-4c59-a181-37a1f8349a08.png)

The List option goes to this page:

![image](https://user-images.githubusercontent.com/1119017/153698149-ec35e04d-d4c1-4b23-9a54-6130daba347a.png)

The Create option goes to this page:

![image](https://user-images.githubusercontent.com/1119017/153698161-74a3020b-887b-40cb-af6b-0caa0d7aa43b.png)

These are just placeholder for now, but later issues will add the proper forms to these pages, along with backend queries to populate them with data.

# Issues Addressed

Closes #53 

