### PR TITLE
pc - extend timeout on frontend mutation testing to 20 minutes, and...

### DIFF
--- a/.github/workflows/01-backend-01-unit.yml
+++ b/.github/workflows/01-backend-01-unit.yml
@@ -4,6 +4,7 @@
 name: 01 Backend 01 Tests (JUnit)
 
 on:
+  workflow_dispatch:
   push:
     branches: [ main ]
   pull_request:

--- a/.github/workflows/01-backend-02-jacoco.yml
+++ b/.github/workflows/01-backend-02-jacoco.yml
@@ -4,6 +4,7 @@
 name: 01 Backend 02 Coverage (Jacoco)
 
 on:
+  workflow_dispatch:
   push:
     branches: [ main ]
   pull_request:

--- a/.github/workflows/01-backend-03-pitest.yml
+++ b/.github/workflows/01-backend-03-pitest.yml
@@ -4,6 +4,7 @@
 name: 01 Backend 03 Mutation Testing (Pitest)
 
 on:
+  workflow_dispatch:
   push:
     branches: [ main ]
   pull_request:

--- a/.github/workflows/02-frontend-00-eslint.yml
+++ b/.github/workflows/02-frontend-00-eslint.yml
@@ -1,6 +1,7 @@
 name: 02 Frontend 00 ESLint (JavaScript style checking)
 
 on:
+  workflow_dispatch:
   pull_request:
   push:
     branches:

--- a/.github/workflows/02-frontend-01-tests.yml
+++ b/.github/workflows/02-frontend-01-tests.yml
@@ -1,6 +1,7 @@
 name: 02 Frontend 01 Tests (JavaScript/Jest)
 
 on:
+  workflow_dispatch:
   pull_request:
   push:
     branches:

--- a/.github/workflows/02-frontend-02-coverage.yml
+++ b/.github/workflows/02-frontend-02-coverage.yml
@@ -1,6 +1,7 @@
 name: 02 Frontend 02 Coverage (JavaScript/Jest)
 
 on:
+  workflow_dispatch:
   pull_request:
   push:
     branches:

--- a/.github/workflows/02-frontend-03-mutation-testing.yml
+++ b/.github/workflows/02-frontend-03-mutation-testing.yml
@@ -1,6 +1,7 @@
 name: 02 Frontend 03 Mutation Testing (JavaScript/Stryker, testing the test suite)
 
 on:
+  workflow_dispatch:
   pull_request:
   push:
     branches:
@@ -9,7 +10,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
 
     strategy:
       matrix:


### PR DESCRIPTION
In this PR we:
* make all jobs available through workflow_dispatch (i.e. manually triggering them)
* extend the timeout on frontend mutation testing to 20 minutes
 
