### PR TITLE
pc - no edit and delete columns except for admins

### DIFF
--- a/frontend/src/main/components/UCSBDates/UCSBDatesTable.js
+++ b/frontend/src/main/components/UCSBDates/UCSBDatesTable.js
@@ -2,10 +2,11 @@ import React from "react";
 import OurTable, { ButtonColumn } from "main/components/OurTable";
 // import { toast } from "react-toastify";
 import { useBackendMutation } from "main/utils/useBackend";
-import { cellToAxiosParamsDelete, onDeleteSuccess} from "main/utils/UCSBDateUtils"
+import { cellToAxiosParamsDelete, onDeleteSuccess } from "main/utils/UCSBDateUtils"
 import { useNavigate } from "react-router-dom";
+import { hasRole } from "main/utils/currentUser";
 
-export default function UCSBDatesTable({ dates }) {
+export default function UCSBDatesTable({ dates, currentUser }) {
 
     const navigate = useNavigate();
 
@@ -42,10 +43,13 @@ export default function UCSBDatesTable({ dates }) {
         {
             Header: 'Date',
             accessor: 'localDateTime',
-        },
-        ButtonColumn("Edit", "primary", editCallback, "UCSBDatesTable"),
-        ButtonColumn("Delete", "danger", deleteCallback, "UCSBDatesTable")
+        }
     ];
+
+    if (hasRole(currentUser, "ROLE_ADMIN")) {
+        columns.push(ButtonColumn("Edit", "primary", editCallback, "UCSBDatesTable"));
+        columns.push(ButtonColumn("Delete", "danger", deleteCallback, "UCSBDatesTable"));
+    } 
 
     // Stryker disable next-line ArrayDeclaration : [columns] is a performance optimization
     const memoizedColumns = React.useMemo(() => columns, [columns]);

--- a/frontend/src/main/pages/UCSBDates/UCSBDatesEditPage.js
+++ b/frontend/src/main/pages/UCSBDates/UCSBDatesEditPage.js
@@ -12,7 +12,10 @@ export default function UCSBDatesEditPage() {
     useBackend(
       // Stryker disable next-line all : don't test internal caching of React Query
       [`/api/ucsbdates?id=${id}`],
-      { method: "GET", url: `/api/ucsbdates?id=${id}` }
+      {  // Stryker disable next-line all : GET is the default, so changing this to "" doesn't introduce a bug
+        method: "GET",
+        url: `/api/ucsbdates?id=${id}`
+      }
     );
 
   const objectToAxiosPutParams = (ucsbDate) => ({
@@ -50,15 +53,12 @@ export default function UCSBDatesEditPage() {
   }
 
   return (
-    <>
-      { (status === 'success') && ucsbDate && (
-        <BasicLayout>
-          <div className="pt-2">
-            <h1>Edit UCSBDate</h1>
-            <UCSBDateForm ucsbDate={ucsbDate} submitAction={onSubmit} buttonLabel="Update" />
-          </div>
-        </BasicLayout>
-      )}
-    </>
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Edit UCSBDate</h1>
+        <UCSBDateForm ucsbDate={ucsbDate} submitAction={onSubmit} buttonLabel="Update" />
+      </div>
+    </BasicLayout>
   )
 }
+

--- a/frontend/src/main/pages/UCSBDates/UCSBDatesEditPage.js
+++ b/frontend/src/main/pages/UCSBDates/UCSBDatesEditPage.js
@@ -14,9 +14,13 @@ export default function UCSBDatesEditPage() {
       [`/api/ucsbdates?id=${id}`],
       {  // Stryker disable next-line all : GET is the default, so changing this to "" doesn't introduce a bug
         method: "GET",
-        url: `/api/ucsbdates?id=${id}`
+        url: `/api/ucsbdates`,
+        params: {
+          id
+        }
       }
     );
+
 
   const objectToAxiosPutParams = (ucsbDate) => ({
     url: "/api/ucsbdates",

--- a/frontend/src/main/pages/UCSBDates/UCSBDatesIndexPage.js
+++ b/frontend/src/main/pages/UCSBDates/UCSBDatesIndexPage.js
@@ -3,7 +3,7 @@ import { useBackend } from 'main/utils/useBackend';
 
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
 import UCSBDatesTable from 'main/components/UCSBDates/UCSBDatesTable';
-import { useCurrentUser} from 'main/utils/currentUser'
+import { useCurrentUser } from 'main/utils/currentUser'
 
 export default function UCSBDatesIndexPage() {
 

--- a/frontend/src/main/pages/UCSBDates/UCSBDatesIndexPage.js
+++ b/frontend/src/main/pages/UCSBDates/UCSBDatesIndexPage.js
@@ -3,8 +3,11 @@ import { useBackend } from 'main/utils/useBackend';
 
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
 import UCSBDatesTable from 'main/components/UCSBDates/UCSBDatesTable';
+import { useCurrentUser} from 'main/utils/currentUser'
 
 export default function UCSBDatesIndexPage() {
+
+  const currentUser = useCurrentUser();
 
   const { data: dates, error: _error, status: _status } =
     useBackend(
@@ -18,7 +21,7 @@ export default function UCSBDatesIndexPage() {
     <BasicLayout>
       <div className="pt-2">
         <h1>UCSBDates</h1>
-        <UCSBDatesTable dates={dates} />
+        <UCSBDatesTable dates={dates} currentUser={currentUser} />
       </div>
     </BasicLayout>
   )

--- a/frontend/src/main/utils/currentUser.js
+++ b/frontend/src/main/utils/currentUser.js
@@ -19,7 +19,7 @@ export function useCurrentUser() {
       return { loggedIn: false, root: null };
     }
   }, {
-    initialData: { loggedIn: false, root: null, initialData:true }
+    initialData: { loggedIn: false, root: null, initialData: true }
   });
 }
 
@@ -35,9 +35,21 @@ export function useLogout() {
 }
 
 export function hasRole(currentUser, role) {
-  return currentUser
-    && currentUser.loggedIn
-    && currentUser.root
-    && currentUser.root.rolesList
-    && currentUser.root.rolesList.includes(role)
+
+  // The following hack is because there is some bug in terms of the
+  // shape of the data returned by useCurrentUser.  Is there a separate 
+  // data level, or not? 
+
+  // We will file an issue to track that down and then remove this hack
+
+  if (currentUser == null) return false;
+
+  if ("data" in currentUser &&
+    "root" in currentUser.data &&
+    currentUser.data.root != null &&
+    "rolesList" in currentUser.data.root) {
+    return currentUser?.data?.root?.rolesList.includes(role);
+  }
+
+  return currentUser?.root?.rolesList?.includes(role);
 }

--- a/frontend/src/main/utils/currentUser.js
+++ b/frontend/src/main/utils/currentUser.js
@@ -48,8 +48,8 @@ export function hasRole(currentUser, role) {
     "root" in currentUser.data &&
     currentUser.data.root != null &&
     "rolesList" in currentUser.data.root) {
-    return currentUser?.data?.root?.rolesList.includes(role);
+    return currentUser.data.root.rolesList.includes(role);
   }
 
-  return currentUser?.root?.rolesList?.includes(role);
+  return currentUser.root?.rolesList?.includes(role);
 }

--- a/frontend/src/tests/components/UCSBDates/UCSBDateForm.test.js
+++ b/frontend/src/tests/components/UCSBDates/UCSBDateForm.test.js
@@ -21,6 +21,7 @@ describe("UCSBDateForm tests", () => {
             </Router>
         );
         await waitFor(() => expect(getByText(/Quarter YYYYQ/)).toBeInTheDocument());
+        await waitFor(() => expect(getByText(/Create/)).toBeInTheDocument());
     });
 
 

--- a/frontend/src/tests/components/UCSBDates/UCSBDatesTable.test.js
+++ b/frontend/src/tests/components/UCSBDates/UCSBDatesTable.test.js
@@ -3,6 +3,7 @@ import { ucsbDatesFixtures } from "fixtures/ucsbDatesFixtures";
 import UCSBDatesTable from "main/components/UCSBDates/UCSBDatesTable"
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
+import { currentUserFixtures } from "fixtures/currentUserFixtures";
 
 
 const mockedNavigate = jest.fn();
@@ -15,22 +16,53 @@ jest.mock('react-router-dom', () => ({
 describe("UserTable tests", () => {
   const queryClient = new QueryClient();
 
-  test("renders without crashing for empty table", () => {
+
+  test("renders without crashing for empty table with user not logged in", () => {
+    const currentUser = null;
+
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <UCSBDatesTable dates={[]} />
+          <UCSBDatesTable dates={[]} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+  });
+  test("renders without crashing for empty table for ordinary user", () => {
+    const currentUser = currentUserFixtures.userOnly;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBDatesTable dates={[]} currentUser={currentUser} />
         </MemoryRouter>
       </QueryClientProvider>
 
     );
   });
 
-  test("Has the expected colum headers and content", () => {
+  test("renders without crashing for empty table for admin", () => {
+    const currentUser = currentUserFixtures.adminUser;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBDatesTable dates={[]} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+  });
+
+  test("Has the expected colum headers and content for adminUser", () => {
+
+    const currentUser = currentUserFixtures.adminUser;
+
     const { getByText, getByTestId } = render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <UCSBDatesTable dates={ucsbDatesFixtures.threeDates} />
+          <UCSBDatesTable dates={ucsbDatesFixtures.threeDates} currentUser={currentUser} />
         </MemoryRouter>
       </QueryClientProvider>
 
@@ -63,11 +95,14 @@ describe("UserTable tests", () => {
 
   });
 
-  test("Edit button navigates to the edit page", async () => {
+  test("Edit button navigates to the edit page for admin user", async () => {
+
+    const currentUser = currentUserFixtures.adminUser;
+
     const { getByText, getByTestId } = render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <UCSBDatesTable dates={ucsbDatesFixtures.threeDates} />
+          <UCSBDatesTable dates={ucsbDatesFixtures.threeDates} currentUser={currentUser} />
         </MemoryRouter>
       </QueryClientProvider>
 

--- a/frontend/src/tests/pages/UCSBDates/UCSBDatesEditPage.test.js
+++ b/frontend/src/tests/pages/UCSBDates/UCSBDatesEditPage.test.js
@@ -68,7 +68,7 @@ describe("UCSBDatesCreatePage tests", () => {
 
     test("Is populated with the data provided", async () => {
 
-        const {getByTestId} = render(
+        const { getByTestId } = render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
                     <UCSBDatesEditPage />
@@ -92,9 +92,9 @@ describe("UCSBDatesCreatePage tests", () => {
 
     test("Changes when you click Update", async () => {
 
-       
 
-        const {getByTestId} = render(
+
+        const { getByTestId } = render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
                     <UCSBDatesEditPage />
@@ -117,15 +117,24 @@ describe("UCSBDatesCreatePage tests", () => {
 
         expect(submitButton).toBeInTheDocument();
 
-        fireEvent.change(quarterYYYYQField, {target: {value: '20224'}})
-        fireEvent.change(nameField, {target: {value: 'Christmas Morning'}})
-        fireEvent.change(localDateTimeField, {target: {value: "2022-12-25T08:00"}})
+        fireEvent.change(quarterYYYYQField, { target: { value: '20224' } })
+        fireEvent.change(nameField, { target: { value: 'Christmas Morning' } })
+        fireEvent.change(localDateTimeField, { target: { value: "2022-12-25T08:00" } })
 
         fireEvent.click(submitButton);
 
-        await waitFor(()=> expect(mockToast).toBeCalled);
+        await waitFor(() => expect(mockToast).toBeCalled);
         expect(mockToast).toBeCalledWith("UCSBDate Updated - id: 17 name: Christmas Morning");
         expect(mockNavigate).toBeCalledWith({ "to": "/ucsbdates/list" });
+
+        expect(axiosMock.history.put.length).toBe(1); // times called
+        expect(axiosMock.history.put[0].params).toEqual({id: 17});
+        expect(axiosMock.history.put[0].data).toBe(JSON.stringify({
+            quarterYYYYQ: '20224',
+            name: "Christmas Morning",
+            localDateTime: "2022-12-25T08:00"
+        })); // posted object
+
     });
 
 });

--- a/frontend/src/tests/pages/UCSBDates/UCSBDatesEditPage.test.js
+++ b/frontend/src/tests/pages/UCSBDates/UCSBDatesEditPage.test.js
@@ -32,7 +32,7 @@ jest.mock('react-router-dom', () => {
     };
 });
 
-describe("UCSBDatesCreatePage tests", () => {
+describe("UCSBDatesEditPage tests", () => {
 
     const axiosMock = new AxiosMockAdapter(axios);
 
@@ -41,7 +41,7 @@ describe("UCSBDatesCreatePage tests", () => {
         axiosMock.resetHistory();
         axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
         axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
-        axiosMock.onGet("/api/ucsbdates?id=17").reply(200, {
+        axiosMock.onGet("/api/ucsbdates",{params: {id: 17}}).reply(200, {
             id: 17,
             quarterYYYYQ: '20221',
             name: "Pi Day",


### PR DESCRIPTION
# Overview

In this PR, we hide the edit and delete columns for non-admins.  They didn't work anyway (resulted in backend permission errors) but we don't want the user to be confused with options that don't work.

# Bugs found and logged

While implementing this, we discovered a bug where the shape of the JSON for the `currentUser` object returned by `useCurrentUser` is inconsistent.  Rather than tracking that down now, we've logged it as a bug in this issue: ( #81 ) and put a workaround into `hasRole`.     Issue #81 involves tracking that down so that we can simplify the hasRole code again.

# Issues Addressed

Closes #79 

