### PR TITLE
Refactor todos controller to return json errors

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/ApiController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/ApiController.java
@@ -1,10 +1,17 @@
 package edu.ucsb.cs156.example.controllers;
 
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
+import net.bytebuddy.implementation.bytecode.Throw;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import edu.ucsb.cs156.example.models.CurrentUser;
 import edu.ucsb.cs156.example.services.CurrentUserService;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+import java.util.Map;
 
 @Slf4j
 public abstract class ApiController {
@@ -13,5 +20,18 @@ public abstract class ApiController {
 
   protected CurrentUser getCurrentUser() {
     return currentUserService.getCurrentUser();
+  }
+
+  protected Object genericMessage(String message) {
+    return Map.of("message", message);
+  }
+
+  @ExceptionHandler({ EntityNotFoundException.class })
+  @ResponseStatus(HttpStatus.NOT_FOUND)
+  public Object handleGenericException(Throwable e) {
+    return Map.of(
+      "type", e.getClass().getSimpleName(),
+      "message", e.getMessage()
+    );
   }
 }

--- a/src/main/java/edu/ucsb/cs156/example/controllers/TodosController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/TodosController.java
@@ -2,11 +2,13 @@ package edu.ucsb.cs156.example.controllers;
 
 import edu.ucsb.cs156.example.entities.Todo;
 import edu.ucsb.cs156.example.entities.User;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
 import edu.ucsb.cs156.example.models.CurrentUser;
 import edu.ucsb.cs156.example.repositories.TodoRepository;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
 import lombok.extern.slf4j.Slf4j;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -33,27 +35,8 @@ import java.util.Optional;
 @Slf4j
 public class TodosController extends ApiController {
 
-    /**
-     * This inner class helps us factor out some code for checking
-     * whether todos exist, and whether they belong to the current user,
-     * along with the error messages pertaining to those situations. It
-     * bundles together the state needed for those checks.
-     */
-    public class TodoOrError {
-        Long id;
-        Todo todo;
-        ResponseEntity<String> error;
-
-        public TodoOrError(Long id) {
-            this.id = id;
-        }
-    }
-
     @Autowired
     TodoRepository todoRepository;
-
-    @Autowired
-    ObjectMapper mapper;
 
     @ApiOperation(value = "List all todos")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
@@ -75,36 +58,24 @@ public class TodosController extends ApiController {
     @ApiOperation(value = "Get a single todo (if it belongs to current user)")
     @PreAuthorize("hasRole('ROLE_USER')")
     @GetMapping("")
-    public ResponseEntity<String> getTodoById(
-            @ApiParam("id") @RequestParam Long id) throws JsonProcessingException {
-        TodoOrError toe = new TodoOrError(id);
+    public Todo getTodoById(
+            @ApiParam("id") @RequestParam Long id) {
+        User currentUser = getCurrentUser().getUser();
+        Todo todo = todoRepository.findByIdAndUser(id, currentUser)
+          .orElseThrow(() -> new EntityNotFoundException(Todo.class, id));
 
-        toe = doesTodoExist(toe);
-        if (toe.error != null) {
-            return toe.error;
-        }
-        toe = doesTodoBelongToCurrentUser(toe);
-        if (toe.error != null) {
-            return toe.error;
-        }
-        String body = mapper.writeValueAsString(toe.todo);
-        return ResponseEntity.ok().body(body);
+        return todo;
     }
 
     @ApiOperation(value = "Get a single todo (no matter who it belongs to, admin only)")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @GetMapping("/admin")
-    public ResponseEntity<String> getTodoById_admin(
-            @ApiParam("id") @RequestParam Long id) throws JsonProcessingException {
-        TodoOrError toe = new TodoOrError(id);
+    public Todo getTodoById_admin(
+            @ApiParam("id") @RequestParam Long id) {
+        Todo todo = todoRepository.findById(id)
+          .orElseThrow(() -> new EntityNotFoundException(Todo.class, id));
 
-        toe = doesTodoExist(toe);
-        if (toe.error != null) {
-            return toe.error;
-        }
-
-        String body = mapper.writeValueAsString(toe.todo);
-        return ResponseEntity.ok().body(body);
+        return todo;
     }
 
     @ApiOperation(value = "Create a new Todo")
@@ -129,140 +100,65 @@ public class TodosController extends ApiController {
     @ApiOperation(value = "Delete a Todo owned by this user")
     @PreAuthorize("hasRole('ROLE_USER')")
     @DeleteMapping("")
-    public ResponseEntity<String> deleteTodo(
+    public Object deleteTodo(
             @ApiParam("id") @RequestParam Long id) {
-        TodoOrError toe = new TodoOrError(id);
+        User currentUser = getCurrentUser().getUser();
+        Todo todo = todoRepository.findByIdAndUser(id, currentUser)
+          .orElseThrow(() -> new EntityNotFoundException(Todo.class, id));
 
-        toe = doesTodoExist(toe);
-        if (toe.error != null) {
-            return toe.error;
-        }
+        todoRepository.delete(todo);
 
-        toe = doesTodoBelongToCurrentUser(toe);
-        if (toe.error != null) {
-            return toe.error;
-        }
-        todoRepository.deleteById(id);
-        return ResponseEntity.ok().body(String.format("todo with id %d deleted", id));
+        return genericMessage("Todo with id %s deleted".formatted(id));
 
     }
 
     @ApiOperation(value = "Delete another user's todo")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @DeleteMapping("/admin")
-    public ResponseEntity<String> deleteTodo_Admin(
+    public Object deleteTodo_Admin(
             @ApiParam("id") @RequestParam Long id) {
-        TodoOrError toe = new TodoOrError(id);
+        Todo todo = todoRepository.findById(id)
+          .orElseThrow(() -> new EntityNotFoundException(Todo.class, id));
 
-        toe = doesTodoExist(toe);
-        if (toe.error != null) {
-            return toe.error;
-        }
+        todoRepository.delete(todo);
 
-        todoRepository.deleteById(id);
-
-        return ResponseEntity.ok().body(String.format("todo with id %d deleted", id));
-
+        return genericMessage("Todo with id %s deleted".formatted(id));
     }
 
     @ApiOperation(value = "Update a single todo (if it belongs to current user)")
     @PreAuthorize("hasRole('ROLE_USER')")
     @PutMapping("")
-    public ResponseEntity<String> putTodoById(
+    public Todo putTodoById(
             @ApiParam("id") @RequestParam Long id,
-            @RequestBody @Valid Todo incomingTodo) throws JsonProcessingException {
-        CurrentUser currentUser = getCurrentUser();
-        User user = currentUser.getUser();
+            @RequestBody @Valid Todo incomingTodo) {
+        User currentUser = getCurrentUser().getUser();
+        Todo todo = todoRepository.findByIdAndUser(id, currentUser)
+          .orElseThrow(() -> new EntityNotFoundException(Todo.class, id));
 
-        TodoOrError toe = new TodoOrError(id);
+        todo.setTitle(incomingTodo.getTitle());
+        todo.setDetails(incomingTodo.getDetails());
+        todo.setDone(incomingTodo.isDone());
 
-        toe = doesTodoExist(toe);
-        if (toe.error != null) {
-            return toe.error;
-        }
-        toe = doesTodoBelongToCurrentUser(toe);
-        if (toe.error != null) {
-            return toe.error;
-        }
+        todoRepository.save(todo);
 
-        incomingTodo.setUser(user);
-        todoRepository.save(incomingTodo);
-
-        String body = mapper.writeValueAsString(incomingTodo);
-        return ResponseEntity.ok().body(body);
+        return todo;
     }
 
     @ApiOperation(value = "Update a single todo (regardless of ownership, admin only, can't change ownership)")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @PutMapping("/admin")
-    public ResponseEntity<String> putTodoById_admin(
+    public Todo putTodoById_admin(
             @ApiParam("id") @RequestParam Long id,
-            @RequestBody @Valid Todo incomingTodo) throws JsonProcessingException {
-        TodoOrError toe = new TodoOrError(id);
+            @RequestBody @Valid Todo incomingTodo) {
+        Todo todo = todoRepository.findById(id)
+          .orElseThrow(() -> new EntityNotFoundException(Todo.class, id));
 
-        toe = doesTodoExist(toe);
-        if (toe.error != null) {
-            return toe.error;
-        }
+        todo.setTitle(incomingTodo.getTitle());
+        todo.setDetails(incomingTodo.getDetails());
+        todo.setDone(incomingTodo.isDone());
 
-        Todo oldTodo = toe.todo;
-        oldTodo.setTitle(incomingTodo.getTitle());
-        oldTodo.setDetails(incomingTodo.getDetails());
-        oldTodo.setDone(incomingTodo.isDone());
-        // do not change the user; even the admin is not allowed to do that.
-        // note that for objects with no concept of "owner", this doesn't apply.
+        todoRepository.save(todo);
 
-        todoRepository.save(oldTodo);
-
-        String body = mapper.writeValueAsString(oldTodo);
-        return ResponseEntity.ok().body(body);
+        return todo;
     }
-
-    /**
-     * Pre-conditions: toe.id is value to look up, toe.todo and toe.error are null
-     *
-     * Post-condition: if todo with id toe.id exists, toe.todo now refers to it, and
-     * error is null.
-     * Otherwise, todo with id toe.id does not exist, and error is a suitable return
-     * value to
-     * report this error condition.
-     */
-    public TodoOrError doesTodoExist(TodoOrError toe) {
-
-        Optional<Todo> optionalTodo = todoRepository.findById(toe.id);
-
-        if (optionalTodo.isEmpty()) {
-            toe.error = ResponseEntity
-                    .badRequest()
-                    .body(String.format("todo with id %d not found", toe.id));
-        } else {
-            toe.todo = optionalTodo.get();
-        }
-        return toe;
-    }
-
-    /**
-     * Pre-conditions: toe.todo is non-null and refers to the todo with id toe.id,
-     * and toe.error is null
-     *
-     * Post-condition: if todo belongs to current user, then error is still null.
-     * Otherwise error is a suitable
-     * return value.
-     */
-    public TodoOrError doesTodoBelongToCurrentUser(TodoOrError toe) {
-        CurrentUser currentUser = getCurrentUser();
-        log.info("currentUser={}", currentUser);
-
-        Long currentUserId = currentUser.getUser().getId();
-        Long todoUserId = toe.todo.getUser().getId();
-        log.info("currentUserId={} todoUserId={}", currentUserId, todoUserId);
-
-        if (todoUserId != currentUserId) {
-            toe.error = ResponseEntity
-                    .badRequest()
-                    .body(String.format("todo with id %d not found", toe.id));
-        }
-        return toe;
-    }
-
 }

--- a/src/main/java/edu/ucsb/cs156/example/errors/EntityNotFoundException.java
+++ b/src/main/java/edu/ucsb/cs156/example/errors/EntityNotFoundException.java
@@ -1,0 +1,8 @@
+package edu.ucsb.cs156.example.errors;
+
+public class EntityNotFoundException extends RuntimeException {
+  public EntityNotFoundException(Class<?> entityType, Object id) {
+    super("%s with id %s not found"
+      .formatted(entityType.getSimpleName(), id.toString()));
+  }
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/TodoRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/TodoRepository.java
@@ -1,11 +1,15 @@
 package edu.ucsb.cs156.example.repositories;
 
 import edu.ucsb.cs156.example.entities.Todo;
+import edu.ucsb.cs156.example.entities.User;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 
 @Repository
 public interface TodoRepository extends CrudRepository<Todo, Long> {
+  Optional<Todo> findByIdAndUser(long id, User user);
   Iterable<Todo> findAllByUserId(Long user_id);
 }

--- a/src/test/java/edu/ucsb/cs156/example/ControllerTestCase.java
+++ b/src/test/java/edu/ucsb/cs156/example/ControllerTestCase.java
@@ -1,5 +1,6 @@
 package edu.ucsb.cs156.example;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -10,6 +11,10 @@ import org.springframework.test.web.servlet.MockMvc;
 import edu.ucsb.cs156.example.services.CurrentUserService;
 import edu.ucsb.cs156.example.services.GrantedAuthoritiesService;
 import edu.ucsb.cs156.example.testconfig.TestConfig;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.io.UnsupportedEncodingException;
+import java.util.Map;
 
 @ActiveProfiles("test")
 @Import(TestConfig.class)
@@ -25,5 +30,9 @@ public abstract class ControllerTestCase {
 
   @Autowired
   public ObjectMapper mapper;
-  
+
+  protected Map<String, Object> responseToJson(MvcResult result) throws UnsupportedEncodingException, JsonProcessingException {
+    String responseString = result.getResponse().getContentAsString();
+    return mapper.readValue(responseString, Map.class);
+  }
 }


### PR DESCRIPTION
Partially implements #68

This PR restructures the todos controller to return json-formatted errors instead of plain strings.
