### PR TITLE
pc - placeholder pages for Students create and list

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -8,10 +8,12 @@ import TodosCreatePage from "main/pages/Todos/TodosCreatePage";
 import TodosEditPage from "main/pages/Todos/TodosEditPage";
 
 import UCSBDatesIndexPage from "main/pages/UCSBDates/UCSBDatesIndexPage";
-
 import UCSBDatesCreatePage from "main/pages/UCSBDates/UCSBDatesCreatePage";
 import UCSBDatesEditPage from "main/pages/UCSBDates/UCSBDatesEditPage";
 
+
+import StudentsIndexPage from "main/pages/Students/StudentsIndexPage";
+import StudentsCreatePage from "main/pages/Students/StudentsCreatePage";
 
 import { hasRole, useCurrentUser } from "main/utils/currentUser";
 
@@ -36,6 +38,22 @@ function App() {
               <Route exact path="/todos/list" element={<TodosIndexPage />} />
               <Route exact path="/todos/create" element={<TodosCreatePage />} />
               <Route exact path="/todos/edit/:todoId" element={<TodosEditPage />} />
+            </>
+          )
+        }
+
+
+        {
+          hasRole(currentUser, "ROLE_USER") && (
+            <>
+              <Route exact path="/students/list" element={<StudentsIndexPage />} />
+            </>
+          )
+        }
+        {
+          hasRole(currentUser, "ROLE_ADMIN") && (
+            <>
+              <Route exact path="/students/create" element={<StudentsCreatePage />} />
             </>
           )
         }

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -63,6 +63,22 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
               }
             </Nav>
 
+
+            <Nav className="mr-auto">
+              {
+                hasRole(currentUser, "ROLE_USER") && (
+                  <NavDropdown title="Students" id="appnavbar-students-dropdown" data-testid="appnavbar-students-dropdown" >
+                    <NavDropdown.Item href="/students/list" data-testid="appnavbar-students-list">List</NavDropdown.Item>
+                    {
+                      hasRole(currentUser, "ROLE_ADMIN") && (
+                        <NavDropdown.Item href="/students/create" data-testid="appnavbar-students-create">Create</NavDropdown.Item>
+                      )
+                    }
+                  </NavDropdown>
+                )
+              }
+            </Nav>
+
             <Nav className="mr-auto">
               {
                 hasRole(currentUser, "ROLE_USER") && (

--- a/frontend/src/main/pages/Students/StudentsCreatePage.js
+++ b/frontend/src/main/pages/Students/StudentsCreatePage.js
@@ -1,0 +1,14 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function StudentsCreatePage() {
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Create New Student</h1>
+        <p>
+          This is where the create page will go
+        </p>
+      </div>
+    </BasicLayout>
+  )
+}

--- a/frontend/src/main/pages/Students/StudentsIndexPage.js
+++ b/frontend/src/main/pages/Students/StudentsIndexPage.js
@@ -1,0 +1,14 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function StudentsIndexPage() {
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Students</h1>
+        <p>
+          This is where the index page will go
+        </p>
+      </div>
+    </BasicLayout>
+  )
+}

--- a/frontend/src/tests/components/Nav/AppNavbar.test.js
+++ b/frontend/src/tests/components/Nav/AppNavbar.test.js
@@ -213,6 +213,53 @@ describe("AppNavbar tests", () => {
 
     });
 
+    test("renders the Students menu correctly for a user", async () => {
+
+        const currentUser = currentUserFixtures.userOnly;
+        const systemInfo = systemInfoFixtures.showingBoth;
+
+        const doLogin = jest.fn();
+
+        const {getByTestId  } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AppNavbar currentUser={currentUser} systemInfo={systemInfo} doLogin={doLogin} />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => expect(getByTestId("appnavbar-students-dropdown")).toBeInTheDocument());
+        const dropdown = getByTestId("appnavbar-students-dropdown");
+        const aElement = dropdown.querySelector("a");
+        expect(aElement).toBeInTheDocument();
+        aElement?.click();
+        await waitFor( () => expect(getByTestId("appnavbar-students-list")).toBeInTheDocument() );
+
+    });
+
+    test("renders the Students menu correctly for an admin", async () => {
+
+        const currentUser = currentUserFixtures.adminUser;
+        const systemInfo = systemInfoFixtures.showingBoth;
+
+        const doLogin = jest.fn();
+
+        const {getByTestId  } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AppNavbar currentUser={currentUser} systemInfo={systemInfo} doLogin={doLogin} />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => expect(getByTestId("appnavbar-students-dropdown")).toBeInTheDocument());
+        const dropdown = getByTestId("appnavbar-students-dropdown");
+        const aElement = dropdown.querySelector("a");
+        expect(aElement).toBeInTheDocument();
+        aElement?.click();
+        await waitFor( () => expect(getByTestId(/appnavbar-students-create/)).toBeInTheDocument() );
+
+    });
 
 });
 

--- a/frontend/src/tests/pages/Students/StudentsCreatePage.test.js
+++ b/frontend/src/tests/pages/Students/StudentsCreatePage.test.js
@@ -1,0 +1,31 @@
+import { render } from "@testing-library/react";
+import StudentsCreatePage from "main/pages/Students/StudentsCreatePage";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import { apiCurrentUserFixtures }  from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+
+describe("StudentsCreatePage tests", () => {
+
+    const axiosMock =new AxiosMockAdapter(axios);
+    axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+
+    const queryClient = new QueryClient();
+    test("renders without crashing", () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <StudentsCreatePage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+    });
+
+});
+
+

--- a/frontend/src/tests/pages/Students/StudentsIndexPage.test.js
+++ b/frontend/src/tests/pages/Students/StudentsIndexPage.test.js
@@ -1,0 +1,30 @@
+import { render } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import StudentsIndexPage from "main/pages/Students/StudentsIndexPage";
+
+import { apiCurrentUserFixtures }  from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+describe("StudentsIndexPage tests", () => {
+
+    const axiosMock =new AxiosMockAdapter(axios);
+    axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+
+    const queryClient = new QueryClient();
+    test("renders without crashing", () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <StudentsIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+    });
+
+});
+
+


### PR DESCRIPTION
# Overview

In order to provide an example, we add placeholder menus for Students Create and Index pages.

These will be filled in later with working code.

# Issues Addressed

Closes #85 

# Screenshots

For Admins:

![students-menu-admin](https://user-images.githubusercontent.com/1119017/153958852-5fdca3b2-87af-47c8-ae08-ba3811179f92.gif)

For ordinary users:

![students-menu-non-admin](https://user-images.githubusercontent.com/1119017/153958994-26e6515c-14a1-4f73-a989-3dd13dab99e5.gif)

