### PR TITLE
AL/BT - Revert removal of ucsbDate null check

### DIFF
--- a/frontend/src/main/components/UCSBDates/UCSBDateForm.js
+++ b/frontend/src/main/components/UCSBDates/UCSBDateForm.js
@@ -4,7 +4,7 @@ import { useForm } from 'react-hook-form'
 import { useNavigate } from 'react-router-dom'
 
 
-function UCSBDateForm({ ucsbDate, submitAction, buttonLabel="Create" }) {
+function UCSBDateForm({ initialUCSBDate, submitAction, buttonLabel="Create" }) {
 
     // Stryker disable all
     const {
@@ -12,7 +12,7 @@ function UCSBDateForm({ ucsbDate, submitAction, buttonLabel="Create" }) {
         formState: { errors },
         handleSubmit,
     } = useForm(
-        { defaultValues: ucsbDate || {}, }
+        { defaultValues: initialUCSBDate || {}, }
     );
     // Stryker enable all
 
@@ -31,7 +31,7 @@ function UCSBDateForm({ ucsbDate, submitAction, buttonLabel="Create" }) {
 
         <Form onSubmit={handleSubmit(submitAction)}>
 
-            {ucsbDate && (
+            {initialUCSBDate && (
                 <Form.Group className="mb-3" >
                     <Form.Label htmlFor="id">Id</Form.Label>
                     <Form.Control
@@ -39,7 +39,7 @@ function UCSBDateForm({ ucsbDate, submitAction, buttonLabel="Create" }) {
                         id="id"
                         type="text"
                         {...register("id")}
-                        value={ucsbDate.id}
+                        value={initialUCSBDate.id}
                         disabled
                     />
                 </Form.Group>

--- a/frontend/src/main/pages/UCSBDates/UCSBDatesEditPage.js
+++ b/frontend/src/main/pages/UCSBDates/UCSBDatesEditPage.js
@@ -61,7 +61,7 @@ export default function UCSBDatesEditPage() {
       <div className="pt-2">
         <h1>Edit UCSBDate</h1>
         {ucsbDate &&
-          <UCSBDateForm ucsbDate={ucsbDate} submitAction={onSubmit} buttonLabel="Update" />
+          <UCSBDateForm initialUCSBDate={ucsbDate} submitAction={onSubmit} buttonLabel="Update" />
         }
       </div>
     </BasicLayout>

--- a/frontend/src/main/pages/UCSBDates/UCSBDatesEditPage.js
+++ b/frontend/src/main/pages/UCSBDates/UCSBDatesEditPage.js
@@ -58,12 +58,12 @@ export default function UCSBDatesEditPage() {
 
   return (
     <BasicLayout>
-      { (status === 'success') && ucsbDate &&
-        <div className="pt-2">
-          <h1>Edit UCSBDate</h1>
+      <div className="pt-2">
+        <h1>Edit UCSBDate</h1>
+        {ucsbDate &&
           <UCSBDateForm ucsbDate={ucsbDate} submitAction={onSubmit} buttonLabel="Update" />
-        </div>
-      }
+        }
+      </div>
     </BasicLayout>
   )
 }

--- a/frontend/src/main/pages/UCSBDates/UCSBDatesEditPage.js
+++ b/frontend/src/main/pages/UCSBDates/UCSBDatesEditPage.js
@@ -58,10 +58,12 @@ export default function UCSBDatesEditPage() {
 
   return (
     <BasicLayout>
-      <div className="pt-2">
-        <h1>Edit UCSBDate</h1>
-        <UCSBDateForm ucsbDate={ucsbDate} submitAction={onSubmit} buttonLabel="Update" />
-      </div>
+      { (status === 'success') && ucsbDate &&
+        <div className="pt-2">
+          <h1>Edit UCSBDate</h1>
+          <UCSBDateForm ucsbDate={ucsbDate} submitAction={onSubmit} buttonLabel="Update" />
+        </div>
+      }
     </BasicLayout>
   )
 }

--- a/frontend/src/tests/components/UCSBDates/UCSBDateForm.test.js
+++ b/frontend/src/tests/components/UCSBDates/UCSBDateForm.test.js
@@ -29,7 +29,7 @@ describe("UCSBDateForm tests", () => {
 
         const { getByText, getByTestId } = render(
             <Router  >
-                <UCSBDateForm ucsbDate={ucsbDatesFixtures.oneDate} />
+                <UCSBDateForm initialUCSBDate={ucsbDatesFixtures.oneDate} />
             </Router>
         );
         await waitFor(() => expect(getByTestId(/UCSBDateForm-id/)).toBeInTheDocument());

--- a/frontend/src/tests/pages/UCSBDates/UCSBDatesEditPage.test.js
+++ b/frontend/src/tests/pages/UCSBDates/UCSBDatesEditPage.test.js
@@ -47,8 +47,8 @@ describe("UCSBDatesEditPage tests", () => {
         });
 
         const queryClient = new QueryClient();
-        test("renders header but table is not present", () => {
-            const {getByText } = render(
+        test("renders header but table is not present", async () => {
+            const {getByText, queryByTestId} = render(
                 <QueryClientProvider client={queryClient}>
                     <MemoryRouter>
                         <UCSBDatesEditPage />
@@ -56,7 +56,7 @@ describe("UCSBDatesEditPage tests", () => {
                 </QueryClientProvider>
             );
             await waitFor(() => expect(getByText("Edit UCSBDate")).toBeInTheDocument());
-            expect(queryByTestId(UCSBDateForm-quarterYYYYQ)).not.toBeInTheDocument();
+            expect(queryByTestId("UCSBDateForm-quarterYYYYQ")).not.toBeInTheDocument();
         });
     });
 


### PR DESCRIPTION
# Overview

This PR fixes a regression that was introduced in #80 by re-adding a removed null check for `ucsbDate`. This will allow `UCSBDateForm` to only be rendered after `ucsbDate` is populated via the backend GET request.

# Bug report:

* Steps to reproduce: 
  - Create a UCSBDate
  - Look at UCSBDate index page.  Click Edit button
* Observed: the fields in the date are blank (not pre-filled in the form)
* Desired: the fields are filled in in the form.

# Before (Observed)

![ucsbdates-edit-regression](https://user-images.githubusercontent.com/1119017/153959173-c78f1b84-4063-47f9-8682-e7c3d6441a9b.gif)

# After (Desired)

![ucsbdates-edit-regression-fixed](https://user-images.githubusercontent.com/1119017/153959454-7871482f-bcf5-4301-a21f-bc53bbe475cd.gif)
